### PR TITLE
Landing v2

### DIFF
--- a/backend/run_local_json_creation.py
+++ b/backend/run_local_json_creation.py
@@ -24,9 +24,9 @@ json_creation = JSONCreation(s3_bucket=None, cf_distribution_id=None, db_connect
 blockspace_json_creation = BlockspaceJSONCreation(s3_bucket=None, cf_distribution_id=None, db_connector=db_connector, api_version='v1')
 
 # Create JSONs
-# print('Creating Master, Landing Page, Metrics, and Chains JSONs...')
-# json_creation.create_all_jsons()
+print('Creating Master, Landing Page, Metrics, and Chains JSONs...')
+json_creation.create_all_jsons()
 
 # Create Blockspace JSONs
-print('Creating Blockspace JSONs...')
-blockspace_json_creation.create_all_jsons()
+# print('Creating Blockspace JSONs...')
+# blockspace_json_creation.create_all_jsons()

--- a/backend/run_local_json_creation.py
+++ b/backend/run_local_json_creation.py
@@ -28,5 +28,5 @@ print('Creating Master, Landing Page, Metrics, and Chains JSONs...')
 json_creation.create_all_jsons()
 
 # Create Blockspace JSONs
-# print('Creating Blockspace JSONs...')
-# blockspace_json_creation.create_all_jsons()
+print('Creating Blockspace JSONs...')
+blockspace_json_creation.create_all_jsons()

--- a/backend/src/api/blockspace_json_creation.py
+++ b/backend/src/api/blockspace_json_creation.py
@@ -692,7 +692,7 @@ class BlockspaceJSONCreation():
                                 "types": ["unix", "gas_fees_absolute_eth", "gas_fees_absolute_usd", "txcount_absolute"]
                                 # daily data for each chain
                             },
-                            "type": "main_category"
+                            "type": "sub_category"
                         }
 
                     comparison_dict['data'][main_cat]['subcategories'][sub_cat]['aggregated'][timeframe_key] = {

--- a/backend/src/api/json_creation.py
+++ b/backend/src/api/json_creation.py
@@ -5,7 +5,7 @@ import pandas as pd
 import numpy as np
 
 from src.adapters.mapping import adapter_mapping, AdapterMapping
-from src.misc.helper_functions import upload_json_to_cf_s3, convert_df_addresses
+from src.misc.helper_functions import upload_json_to_cf_s3, db_addresses_to_checksummed_addresses
 
 class JSONCreation():
 
@@ -594,7 +594,7 @@ class JSONCreation():
             contracts = self.db_connector.get_top_contracts_for_all_chains_with_change(top_by='gas', days=days, limit=6)
             # replace NaNs with Nones
             contracts = contracts.replace({np.nan: None})
-            contracts = convert_df_addresses(contracts, ['address'])
+            contracts = db_addresses_to_checksummed_addresses(contracts, ['address'])
             
             landing_dict['data']['top_contracts'][f"{days}d"] = {
                 "data": contracts[

--- a/backend/src/api/json_creation.py
+++ b/backend/src/api/json_creation.py
@@ -20,49 +20,57 @@ class JSONCreation():
                 'name': 'Total value locked (on chain)',
                 'metric_keys': ['tvl', 'tvl_eth'],
                 'units': ['USD', 'ETH'],
-                'avg': False
+                'avg': False,
+                'all_l2s_aggregate': 'sum'
             }
             ,'txcount': {
                 'name': 'Transaction count',
                 'metric_keys': ['txcount'],
                 'units': ['-'],
-                'avg': True
+                'avg': True,
+                'all_l2s_aggregate': 'sum'
             }
             ,'daa': {
                 'name': 'Daily active addresses',
                 'metric_keys': ['daa'],
                 'units': ['-'],
-                'avg': True
+                'avg': True,
+                'aggregate': 'weighted_mean'
             }
             ,'stables_mcap': {
                 'name': 'Stablecoin market cap',
                 'metric_keys': ['stables_mcap', 'stables_mcap_eth'],
                 'units': ['USD', 'ETH'],
-                'avg': False
+                'avg': False,
+                'all_l2s_aggregate': 'sum'
             }
             ,'fees': {
                 'name': 'Fees paid',
                 'metric_keys': ['fees_paid_usd', 'fees_paid_eth'],
                 'units': ['USD', 'ETH'],
-                'avg': True
+                'avg': True,
+                'all_l2s_aggregate': 'sum'
             }
             ,'rent_paid': {
                 'name': 'Rent paid to L1',
                 'metric_keys': ['rent_paid_usd', 'rent_paid_eth'],
                 'units': ['USD', 'ETH'],
-                'avg': True
+                'avg': True,
+                'all_l2s_aggregate': 'sum'
             }
             ,'profit': {
                 'name': 'Profit',
                 'metric_keys': ['profit_usd', 'profit_eth'],
                 'units': ['USD', 'ETH'],
-                'avg': True
+                'avg': True,
+                'all_l2s_aggregate': 'sum'
             }
             ,'txcosts': {
                 'name': 'Transaction costs',
                 'metric_keys': ['txcosts_median_usd', 'txcosts_median_eth'],
                 'units': ['USD', 'ETH'],
-                'avg': True
+                'avg': True,
+                'all_l2s_aggregate': 'weighted_mean'
             }
         }
 
@@ -337,6 +345,63 @@ class JSONCreation():
         val = (current - previous) / previous 
         return round(val,4)
     
+    ## This method generates a dict containing aggregate daily values for all_l2s (all chains except Ethereum) for a specific metric_id
+    def generate_all_l2s_metric_dict(self, df, metric_id):
+        metric = self.metrics[metric_id]
+        mks = metric['metric_keys']
+
+        # filter df for all_l2s (all chains except Ethereum)
+        df_tmp = df.loc[(df.origin_key!='ethereum') & (df.metric_key.isin(mks))]
+        
+        # group by unix and metric_key and sum up the values or calculate the mean (depending on the metric)
+        if metric['all_l2s_aggregate'] == 'sum':
+            df_tmp = df_tmp.groupby(['date', 'unix', 'metric_key']).sum().reset_index()
+        elif metric['all_l2s_aggregate'] == 'weighted_mean':
+            ## calculate weighted mean based on txcount of each chain
+            # get txcount of each chain
+            df_txcount = df.loc[(df.origin_key!='ethereum') & (df.metric_key=='txcount')]
+
+            # merge txcount df with df_tmp
+            df_tmp = df_tmp.merge(df_txcount[['date', 'origin_key', 'value']], on=['date', 'origin_key'], how='left', suffixes=('', '_txcount'))
+
+            # calculate weighted mean by multiplying the value of each chain with the txcount of that chain and then summing up all values and dividing by the sum of all txcounts
+            df_tmp['value'] = df_tmp['value'] * df_tmp['value_txcount']
+            df_tmp = df_tmp.groupby(['date', 'unix', 'metric_key']).sum().reset_index()
+            df_tmp['value'] = df_tmp['value'] / df_tmp['value_txcount']
+
+            # drop value_txcount column
+            df_tmp.drop(columns=['value_txcount'], inplace=True)
+
+        df_tmp = df_tmp.loc[df_tmp.metric_key.isin(mks), ["unix", "value", "metric_key"]].pivot(index='unix', columns='metric_key', values='value').reset_index()
+        df_tmp.sort_values(by=['unix'], inplace=True, ascending=True)
+        df_tmp.columns.name = None
+
+        df_tmp = self.df_rename(df_tmp, metric_id, True)
+
+        mk_list = df_tmp.values.tolist()
+
+        if len(self.metrics[metric_id]['units']) == 1:
+            mk_list_int = [[int(i[0]),i[1]] for i in mk_list]
+        elif len(self.metrics[metric_id]['units']) == 2:
+            mk_list_int = [[int(i[0]),i[1], i[2]] for i in mk_list]
+        else:
+            raise NotImplementedError("Only 1 or 2 units are supported")
+        
+        chains_list_no_eth = self.chains_list.copy()
+        chains_list_no_eth.remove('ethereum')
+
+        dict = {
+            "metric_name": self.metrics[metric_id]['name'],
+            "source": self.db_connector.get_metric_sources(metric_id, chains_list_no_eth),
+            "avg": self.metrics[metric_id]['avg'],
+            "daily": {
+                "types": df_tmp.columns.to_list(),
+                "data": mk_list_int
+            }
+        }
+
+        return dict
+    
     ##### FILE HANDLERS #####
     def save_to_json(self, data, path):
         #create directory if not exists
@@ -506,9 +571,19 @@ class JSONCreation():
                             "chains": self.generate_chains_userbase_dict(df, 'weekly')
                             }
                         }
-                    }
+                    },
+                "all_l2s": {
+                    "chain_id": "all_l2s",
+                    "chain_name": "All L2s",
+                    "symbol": "-",
+                    "metrics": {}
                 }
             }
+        }
+
+        for metric_id in ['txcount', 'stables_mcap', 'fees', 'rent_paid', 'txcosts']:
+            landing_dict['data']['all_l2s']['metrics'][metric_id] = self.generate_all_l2s_metric_dict(df, metric_id)
+
 
         if self.s3_bucket == None:
             self.save_to_json(landing_dict, 'landing_page')

--- a/backend/src/misc/helper_functions.py
+++ b/backend/src/misc/helper_functions.py
@@ -7,6 +7,7 @@ import unicodedata
 from datetime import datetime
 import boto3
 import os
+import eth_utils
 
 ## API interaction functions
 def api_get_call(url, sleeper=0.5, retries=15, header=None, _remove_control_characters=False, as_json=True):
@@ -173,6 +174,12 @@ def prepare_df_kpis(df, metric_key, origin_key):
         df.drop(df[df.date == today].index, inplace=True, errors='ignore')
         df.value.fillna(0, inplace=True)
         return df
+
+## convert df address columns to checksummed addresses
+def convert_df_addresses(df, address_cols):
+    for col in address_cols:
+        df[col] = df[col].apply(lambda x: eth_utils.to_checksum_address(bytes(x)))
+    return df
 
 ## Some simple Adapter print functions
 def clean_params(params:dict):

--- a/backend/src/misc/helper_functions.py
+++ b/backend/src/misc/helper_functions.py
@@ -176,7 +176,7 @@ def prepare_df_kpis(df, metric_key, origin_key):
         return df
 
 ## convert df address columns to checksummed addresses
-def convert_df_addresses(df, address_cols):
+def db_addresses_to_checksummed_addresses(df, address_cols):
     for col in address_cols:
         df[col] = df[col].apply(lambda x: eth_utils.to_checksum_address(bytes(x)))
     return df


### PR DESCRIPTION
- added `db_addresses_to_checksummed_addresses` method for converting bytea address column from DB in dataframes to checksummed string -- updated files with contract dataframes to use this method
- **NOTE:** this requires the `eth_utils` package - please install if not already installed on server
- added `all_l2s_aggregate` field for checking type of aggregation strategy to use
- added `generate_all_l2s_metric_dict` method - This method generates a dict containing aggregate daily values for all_l2s (all chains except Ethereum) for a specific metric_id - added this to landing_page.json
- added `get_top_contracts_for_all_chains_with_change` method - This function is used to get the top contracts by category for the landing page's top 6 contracts section. It returns the top 6 contracts by gas fees for all categories and also returns the change in the top_by metric for the given contract and time period - added this to landing_page.json

- cleaned up comments in blockspace_json_creation file