### PR TITLE
Remove old columns from oss-directory table

### DIFF
--- a/backend/src/adapters/adapter_oso.py
+++ b/backend/src/adapters/adapter_oso.py
@@ -69,12 +69,6 @@ class AdapterOSO(AbstractAdapter):
         df['active'] = True # project is marked active because it is in the OSS directory
         df['source'] = 'OSS_DIRECTORY'
 
-        # to be removed columns!!!
-        df['main_github'] = df['github'].apply(lambda x: x[0]['url'] if isinstance(x, list) else None) # get the first github url
-        df['main_github'] = df['main_github'].apply(lambda x: x.split('/')[-1] if isinstance(x, str) else None) # remove the url and keep only the name of the github repo
-        df['website'] = df['websites'].apply(lambda x: x[0]['url'] if isinstance(x, list) else None) # get the first website url
-        df['twitter'] = df['social'].apply(lambda x: x['twitter'][0]['url'] if not pd.isna(x) and 'twitter' in x and isinstance(x['twitter'], list) else None) # get the first X url
-         
         return df	
 
     ## Projects that are in our db (df_active_projects) but not in the export from OSS (df_oss) are dropped projects

--- a/backend/src/db_connector.py
+++ b/backend/src/db_connector.py
@@ -1262,14 +1262,15 @@ class DbConnector:
 
         ### OLI functions
         def get_active_projects(self):
+                # if multiple githubs, websites or socials, it will always take the first one in the list!
                 exec_string = """
                         SELECT 
                                 "name", 
                                 display_name, 
                                 description, 
-                                main_github,
-                                twitter,
-                                website 
+                                replace((github->0->>'url'), 'https://github.com/', '') AS main_github,
+                                (social->'twitter'->0->>'url') AS twitter, -- remove 'https://twitter.com/' once front end is capable!
+                                (websites->0->>'url') AS website
                         FROM public.oli_oss_directory 
                         WHERE active = true
                         """
@@ -1279,10 +1280,10 @@ class DbConnector:
         def get_projects_for_airtable(self):
                 exec_string = """
                         SELECT 
-                                "name" as "Name", 
-                                display_name as "Display Name", 
-                                description as "Description", 
-                                main_github as "Github" 
+                                "name" AS "Name", 
+                                display_name AS "Display Name", 
+                                description AS "Description", 
+                                replace((github->0->>'url'), 'https://github.com/', '') AS "Github" 
                         FROM public.oli_oss_directory
                         WHERE active = True;
                         """


### PR DESCRIPTION
I removed all dependencies (I could find) of the old columns, so now we should be able to drop the following columns from oli_oss_directory table: 

* website
* main_github
* twitter