### PR TITLE
Oli/label features ground truth

### DIFF
--- a/backend/airflow/dags/oli/oli_airtable.py
+++ b/backend/airflow/dags/oli/oli_airtable.py
@@ -326,6 +326,84 @@ def etl():
             print(f'No attestations since {yesterday}.')
 
     @task()
+    def airtable_write_protocol_likely_to_automated():
+        """
+        Surface contracts flagged as 'protocol-contract-likely' by the automated labeler back into
+        'Label Pool Automated' so a human reviewer can assign owner_project / temp_owner_project /
+        gtp_no_owner_project — all validation lives in a single Airtable table.
+
+        Source: extract_automated_protocol_likely.sql.j2 (rows where the automated attester wrote
+        owner_project='protocol-contract-likely' as a sentinel for human review).
+
+        Rows arrive with `is_protocol_contract_likely=True`, `approve=False`, and a `_comment`
+        prompting owner-project assignment. `owner_project` is left blank (linked record); the
+        reviewer fills `owner_project` (linked) for known protocols OR `temp_owner_project` (text)
+        for novel ones, OR checks `gtp_no_owner_project` to confirm there is no owner.
+        """
+        import pandas as pd
+        from eth_utils import to_checksum_address
+        from src.db_connector import DbConnector
+        import src.misc.airtable_functions as at
+        from pyairtable import Api
+        import os
+
+        db_connector = DbConnector()
+        df = db_connector.execute_jinja('/oli/extract_automated_protocol_likely.sql.j2', {}, load_into_df=True)
+        if df.empty:
+            print('No protocol-likely contracts to surface.')
+            return
+
+        AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
+        AIRTABLE_BASE_ID = os.getenv("AIRTABLE_BASE_ID")
+        api = Api(AIRTABLE_API_KEY)
+        table = api.table(AIRTABLE_BASE_ID, 'Label Pool Automated')
+
+        # Normalise address to checksum format
+        df['address'] = df.apply(
+            lambda row: to_checksum_address('0x' + bytes(row['address']).hex())
+            if isinstance(row['address'], (bytes, bytearray, memoryview))
+            else to_checksum_address(row['address'])
+            if row['chain_id'].startswith('eip155') else row['address'],
+            axis=1
+        )
+
+        # Dedup against existing 'Label Pool Automated' rows (address only — origin_key is a
+        # linked record and would require resolving recIDs; address is unique enough here).
+        df_existing = at.read_airtable(table)
+        if not df_existing.empty and 'address' in df_existing.columns:
+            existing_addrs = set(df_existing['address'].str.lower())
+            df = df[~df['address'].str.lower().isin(existing_addrs)]
+        if df.empty:
+            print('All protocol-likely contracts already in Label Pool Automated.')
+            return
+
+        # Map usage_category slug → Airtable Sub Categories recID (linked record)
+        df_cat = at.read_airtable(api.table(AIRTABLE_BASE_ID, 'Sub Categories'))
+        df = df.replace({'usage_category': df_cat.set_index('category_id')['id']})
+        df['usage_category'] = df['usage_category'].apply(
+            lambda x: [x] if pd.notna(x) and str(x).startswith('rec') else [])
+
+        # Map chain_id (caip2) → Airtable Chains recID, rename column to origin_key (linked)
+        df_chains = at.read_airtable(api.table(AIRTABLE_BASE_ID, 'Chains'))
+        df = df.replace({'chain_id': df_chains.set_index('caip2')['id']})
+        df['chain_id'] = df['chain_id'].apply(
+            lambda x: [x] if pd.notna(x) and str(x).startswith('rec') else [])
+        df = df.rename(columns={'chain_id': 'origin_key'})
+
+        # Reviewer-facing scaffold
+        df['_comment'] = 'protocol-likely: assign owner_project, set temp_owner_project (novel), or check gtp_no_owner_project.'
+        df['_source'] = 'gtp-automated_labeler_protocol_likely'
+        df['is_protocol_contract_likely'] = True
+        df['approve'] = False
+
+        # Drop the sentinel slug — leaving owner_project blank prompts manual assignment
+        df = df.drop(columns=[c for c in ['attester', 'owner_project'] if c in df.columns],
+                     errors='ignore')
+
+        at.push_to_airtable(table, df)
+        print(f'Wrote {len(df)} protocol-likely contracts to Label Pool Automated.')
+
+    @task()
     def airtable_write_depreciated_owner_project():
         """
         This task writes the remap owner project table to Airtable.
@@ -421,11 +499,6 @@ def etl():
                 tags = df_merged.set_index('tag_id')['value'].to_dict()
                 address = group[0][0].replace('\\x', '0x')
                 chain_id = group[0][1]
-                # TODO(contract_label_review): same diff capture as in airtable_read_automated_labels().
-                # review_source = 'airtable_reattest' here (protocol-likely owner_project assignment flow).
-                # gtp_owner_project = tags.get('owner_project') — this is the primary signal being captured.
-                # gtp_no_owner_project from new "Label Pool Reattest" Airtable checkbox field.
-                # Requires db_connector.get_contract_label_features() + insert_contract_label_review().
                 # submit offchain attestation
                 response = oli.submit_label(address, chain_id, tags)
                 print(f"Successfully attested label for {address} on {chain_id}: {response}")
@@ -450,7 +523,7 @@ def etl():
         api = Api(AIRTABLE_API_KEY)
         table = api.table(AIRTABLE_BASE_ID, 'Label Pool Automated')
 
-        df = at.read_all_label_pool_reattest(api, AIRTABLE_BASE_ID, table, approved=True)
+        df = at.read_all_label_pool_automated(api, AIRTABLE_BASE_ID, table, approved=True)
         if df is None or df.empty:
             print('No approved automated labels to re-attest.')
             return
@@ -461,16 +534,25 @@ def etl():
         df = df.drop_duplicates(subset=['address', 'chain_id'])
         ids = df['id'].tolist()
 
-        # Melt to tag_id/value pairs (owner_project absent — automated labeler never sets it)
-        df = df[['address', 'chain_id', 'contract_name', 'usage_category']]
-        df = df.melt(id_vars=['address', 'chain_id'], var_name='tag_id', value_name='value')
-        df['address'] = df['address'].str.lower()
-        df = df[df['value'].notnull()]
+        # Per-row review-diff context (NOT melted — keep the row data intact)
+        review_ctx = df.set_index(['address', 'chain_id'])[
+            ['ai_contract_name', 'ai_usage_category', 'temp_owner_project', 'gtp_no_owner_project']
+        ].to_dict('index')
 
-        for group in df.groupby(['address', 'chain_id']):
+        # Melt to tag_id/value pairs. owner_project IS now possibly set (linked OSS slug after coalesce).
+        df_tags = df[['address', 'chain_id', 'contract_name', 'owner_project', 'usage_category']]
+        df_tags = df_tags.melt(id_vars=['address', 'chain_id'], var_name='tag_id', value_name='value')
+        df_tags['address'] = df_tags['address'].str.lower()
+        df_tags = df_tags[df_tags['value'].notnull()]
+
+        # caip2 → origin_key inverse lookup (for contract_label_features primary key)
+        from src.main_config import get_main_config
+        chain_id_to_origin_key = {f"eip155:{c.chain_id}": c.origin_key for c in get_main_config()
+                                  if getattr(c, 'chain_id', None)}
+
+        for group in df_tags.groupby(['address', 'chain_id']):
             df_auto = group[1].copy()
             df_auto['source'] = 'automated'
-            # Fill in any missing tags from the gold table (OLI_gtp_pk prior attestations)
             df_gold = db_connector.get_all_prior_attested_labels(
                 group[0][0], group[0][1], "0xA725646C05E6BB813D98C5ABB4E72DF4BCF00B56")
             if not df_gold.empty:
@@ -487,37 +569,41 @@ def etl():
             tags = df_merged.set_index('tag_id')['value'].to_dict()
             address = group[0][0].replace('\\x', '0x')
             chain_id = group[0][1]
+            origin_key = chain_id_to_origin_key.get(chain_id)
 
-            # TODO(contract_label_review): before oli.submit_label(), capture the review diff.
-            # Steps:
-            #   1. Look up AI originals: ai_row = db_connector.get_contract_label_features([(address, origin_key)])
-            #      origin_key derived from chain_id via sys_main_conf lookup or Config.SUPPORTED_CHAINS inverse.
-            #   2. Detect changes vs what Airtable has (human may have edited contract_name / usage_category):
-            #      gtp_contract_name  = tags.get('contract_name')  if tags.get('contract_name')  != ai_row.get('ai_contract_name')  else None
-            #      gtp_usage_category = tags.get('usage_category') if tags.get('usage_category') != ai_row.get('ai_usage_category') else None
-            #      gtp_owner_project  = tags.get('owner_project') or None
-            #      gtp_no_owner       = bool(row_data.get('gtp_no_owner_project', False))  ← new Airtable checkbox field
-            #   3. Write diff row:
-            #      db_connector.insert_contract_label_review([{
-            #          'address': address, 'origin_key': origin_key,
-            #          'labeled_at': ai_row.get('labeled_at'),
-            #          'reviewed_at': datetime.utcnow(),
-            #          'review_source': 'airtable_automated',
-            #          'ai_contract_name': ai_row.get('ai_contract_name'),
-            #          'ai_usage_category': ai_row.get('ai_usage_category'),
-            #          'ai_confidence': ai_row.get('ai_confidence'),
-            #          'ai_owner_project_likely': ai_row.get('ai_owner_project_likely', False),
-            #          'gtp_contract_name': gtp_contract_name,
-            #          'gtp_usage_category': gtp_usage_category,
-            #          'gtp_owner_project': gtp_owner_project,
-            #          'gtp_no_owner_project': gtp_no_owner,
-            #          'name_was_changed': gtp_contract_name is not None,
-            #          'category_was_changed': gtp_usage_category is not None,
-            #          'owner_was_assigned': gtp_owner_project is not None,
-            #      }])
-            # Requires new Airtable fields in "Label Pool Automated":
-            #   - gtp_owner_project  (single line text)  — human assigns protocol slug
-            #   - gtp_no_owner_project (checkbox)         — human confirms no protocol owner
+            # ── Review diff capture ────────────────────────────────────────────
+            try:
+                ctx = review_ctx.get(group[0], {})
+                ai_row = {}
+                if origin_key:
+                    ai_row = db_connector.get_contract_label_features([(address, origin_key)]).get(
+                        (address.lower(), origin_key), {})
+                ai_name = ai_row.get('ai_contract_name') or ctx.get('ai_contract_name')
+                ai_cat  = ai_row.get('ai_usage_category') or ctx.get('ai_usage_category')
+                gtp_name = tags.get('contract_name')  if tags.get('contract_name')  not in (None, ai_name) else None
+                gtp_cat  = tags.get('usage_category') if tags.get('usage_category') not in (None, ai_cat)  else None
+                gtp_owner = tags.get('owner_project') or ctx.get('temp_owner_project') or None
+                gtp_no_owner = bool(ctx.get('gtp_no_owner_project', False))
+                if origin_key:
+                    db_connector.insert_contract_label_review([{
+                        'address': address,
+                        'origin_key': origin_key,
+                        'labeled_at': ai_row.get('labeled_at'),
+                        'reviewed_at': datetime.utcnow(),
+                        'review_source': 'airtable_automated',
+                        'ai_contract_name': ai_name,
+                        'ai_usage_category': ai_cat,
+                        'ai_confidence': ai_row.get('ai_confidence'),
+                        'ai_owner_project_likely': bool(ai_row.get('ai_owner_project_likely', False)),
+                        'gtp_contract_name': gtp_name,
+                        'gtp_usage_category': gtp_cat,
+                        'gtp_owner_project': gtp_owner,
+                        'gtp_no_owner_project': gtp_no_owner,
+                    }])
+            except Exception as e:
+                # Non-fatal — attestation must still proceed
+                print(f"[contract_label_review] insert failed for {address}/{chain_id}: {e}")
+
             response = oli.submit_label(address, chain_id, tags)
             print(f'Re-attested {address} on {chain_id}: {response}')
 
@@ -670,7 +756,8 @@ def etl():
     write_contracts = airtable_write_contracts()  ## write contracts from DB to airtable
     write_pool = airtable_write_label_pool_reattest() ## write label pool reattest from DB to airtable
     write_remap = airtable_write_depreciated_owner_project() ## write remap owner project from DB to airtable
-    
+    write_protocol_likely = airtable_write_protocol_likely_to_automated() ## write protocol-likely contracts back to Label Pool Automated for owner-project review
+
     ## Revoke old attestations from label pool
     revoke_onchain = revoke_old_attestations() ## revoke old attestations from the label pool
 

--- a/backend/airflow/dags/oli/oli_airtable.py
+++ b/backend/airflow/dags/oli/oli_airtable.py
@@ -500,6 +500,11 @@ def etl():
                 tags = df_merged.set_index('tag_id')['value'].to_dict()
                 address = group[0][0].replace('\\x', '0x')
                 chain_id = group[0][1]
+                # TODO(contract_label_review): same diff capture as in airtable_read_automated_labels().
+                # review_source = 'airtable_reattest' here (protocol-likely owner_project assignment flow).
+                # gtp_owner_project = tags.get('owner_project') — this is the primary signal being captured.
+                # gtp_no_owner_project from new "Label Pool Reattest" Airtable checkbox field.
+                # Requires db_connector.get_contract_label_features() + insert_contract_label_review().
                 # submit offchain attestation
                 response = oli.submit_label(address, chain_id, tags)
                 print(f"Successfully attested label for {address} on {chain_id}: {response}")
@@ -561,6 +566,37 @@ def etl():
             tags = df_merged.set_index('tag_id')['value'].to_dict()
             address = group[0][0].replace('\\x', '0x')
             chain_id = group[0][1]
+
+            # TODO(contract_label_review): before oli.submit_label(), capture the review diff.
+            # Steps:
+            #   1. Look up AI originals: ai_row = db_connector.get_contract_label_features([(address, origin_key)])
+            #      origin_key derived from chain_id via sys_main_conf lookup or Config.SUPPORTED_CHAINS inverse.
+            #   2. Detect changes vs what Airtable has (human may have edited contract_name / usage_category):
+            #      gtp_contract_name  = tags.get('contract_name')  if tags.get('contract_name')  != ai_row.get('ai_contract_name')  else None
+            #      gtp_usage_category = tags.get('usage_category') if tags.get('usage_category') != ai_row.get('ai_usage_category') else None
+            #      gtp_owner_project  = tags.get('owner_project') or None
+            #      gtp_no_owner       = bool(row_data.get('gtp_no_owner_project', False))  ← new Airtable checkbox field
+            #   3. Write diff row:
+            #      db_connector.insert_contract_label_review([{
+            #          'address': address, 'origin_key': origin_key,
+            #          'labeled_at': ai_row.get('labeled_at'),
+            #          'reviewed_at': datetime.utcnow(),
+            #          'review_source': 'airtable_automated',
+            #          'ai_contract_name': ai_row.get('ai_contract_name'),
+            #          'ai_usage_category': ai_row.get('ai_usage_category'),
+            #          'ai_confidence': ai_row.get('ai_confidence'),
+            #          'ai_owner_project_likely': ai_row.get('ai_owner_project_likely', False),
+            #          'gtp_contract_name': gtp_contract_name,
+            #          'gtp_usage_category': gtp_usage_category,
+            #          'gtp_owner_project': gtp_owner_project,
+            #          'gtp_no_owner_project': gtp_no_owner,
+            #          'name_was_changed': gtp_contract_name is not None,
+            #          'category_was_changed': gtp_usage_category is not None,
+            #          'owner_was_assigned': gtp_owner_project is not None,
+            #      }])
+            # Requires new Airtable fields in "Label Pool Automated":
+            #   - gtp_owner_project  (single line text)  — human assigns protocol slug
+            #   - gtp_no_owner_project (checkbox)         — human confirms no protocol owner
             response = oli.submit_label(address, chain_id, tags)
             print(f'Re-attested {address} on {chain_id}: {response}')
 

--- a/backend/airflow/dags/oli/oli_automated_labeler.py
+++ b/backend/airflow/dags/oli/oli_automated_labeler.py
@@ -14,7 +14,7 @@ from src.misc.airflow_utils import alert_via_webhook, claude_fix_on_failure
     dag_id='oli_automated_labeler',
     description='AI-based labeling of unlabeled contracts, with OLI attestation',
     tags=['oli', 'daily', 'labeling'],
-    start_date=datetime(2025, 1, 1),
+    start_date=datetime(2026, 4, 22),
     schedule='30 01 * * 1',  # 1:30am UTC every Monday — after oli_airtable (00:50) refreshes materialized views
 )
 def etl():

--- a/backend/labeling/ai_classifier.py
+++ b/backend/labeling/ai_classifier.py
@@ -992,6 +992,30 @@ Category hints from events: {', '.join(log_signals['category_hints']) or 'none'}
                 args.setdefault('reasoning', '')
                 # Attach novel_tokens so sentinel can use them without re-computing
                 args['novel_tokens'] = novel_tokens
+                # TODO(contract_label_features): extend return dict with pre-computed signals so
+                # automated_labeler.py can write them to contract_label_features without re-computing.
+                # Add to args before return:
+                #   args['common_tokens']              = common_tokens
+                #   args['matched_routers']            = list(matched_routers)
+                #   args['matched_dex_pools']          = list(matched_dex_pools)
+                #   args['calls_into_dex_pool_swap']   = calls_into_dex_pool_swap
+                #   args['matched_lending']            = list(matched_lending)
+                #   args['matched_staking']            = list(matched_staking)
+                #   args['matched_bridges']            = list(matched_bridges)
+                #   args['matched_oracle_fns']         = list(matched_oracle_fns)
+                #   args['delegates_to']               = this_contract_delegates_to or None
+                #   args['raw_delegate']               = this_contract_raw_delegate
+                #   args['all_traces_empty']           = all_traces_empty
+                #   args['traces_only_raw_opcodes']    = traces_only_raw_opcodes
+                #   args['named_contracts_in_traces']  = sorted(named_contracts_in_traces)
+                #   args['caller_diversity_pct']       = caller_diversity_pct
+                #   args['caller_diversity_label']     = caller_diversity_label
+                #   args['unique_callers']             = unique_callers
+                #   args['total_traces_sampled']       = total_traces_with_caller
+                #   args['log_signals']                = log_signals   (full decode_log_signals dict)
+                #   args['sentinel_fired']             = False          (True in sentinel fast-path)
+                # Sentinel fast-path (see lines ~1060–1090) also needs sentinel_fired=True added.
+                # Fallback return (see lines ~1006–1012) needs all fields with safe empty defaults.
                 return args
             logger.warning(f"[Classifier] Could not parse Gemini response for {address}: {raw[:120]!r}")
 
@@ -1003,6 +1027,8 @@ Category hints from events: {', '.join(log_signals['category_hints']) or 'none'}
     except Exception as e:
         logger.error(f"[Classifier] Gemini API error for {address}: {e}")
 
+    # TODO(contract_label_features): add all pre-computed signal keys with safe empty defaults
+    # to this fallback return so contract_label_features always gets a complete row even on failure.
     return {
         'contract_name': bs_name if bs_name != 'unknown' else f"Contract-{address[:8]}",
         'usage_category': fallback_id,

--- a/backend/labeling/ai_classifier.py
+++ b/backend/labeling/ai_classifier.py
@@ -348,13 +348,44 @@ _SYSTEM_INSTRUCTION = """You are a smart contract protocol analyst. Classify the
 
 ## HOW TO CLASSIFY
 
-Two primary sources of truth, in order of reliability:
+Three primary sources of truth, in order of reliability:
 1. **Verified name** — if the contract is source-verified with a real name, read it as a human would. "GridMining" is gaming. "LendingPool" is lending. "BridgeRouter" is bridge. Trust your semantic understanding of what the name describes. Use traces to confirm or disambiguate, not to override.
 2. **Trace behavior** — what the contract actually does: what it calls, what events it emits, what state it changes. Classify by function.
+3. **GitHub repository** — if `github.has_valid_repo=true`, the linked repo is a strong identity + ownership signal. Treat it like verification: do NOT default such a contract to trading/MEV in PATH G1/G2/G3 — classify by trace content or name semantics instead.
 
-Numerical signals (success_rate, DAA/tx, rel_cost) are tiebreakers. They shift confidence but do not override clear semantic or trace evidence.
+Numerical signals (success_rate, DAA/tx, rel_cost) are tiebreakers in most cases. They shift
+confidence but do not override clear semantic or trace evidence.
+
+**Exception — avg_daa is a primary signal for public/private classification.**
+A contract with avg_daa ≥ chain_median_daa is public infrastructure by definition (real users from
+many addresses). It cannot be a private trading bot regardless of trace shape. Conversely, a contract
+with avg_daa far below chain_median (single-digit DAA on a chain whose median is hundreds) is a
+private operator, and "DEXAggregator" / "DEX" labels are invalid for it without strong evidence
+that the few callers are real public EOAs (not admin keepers cycling addresses). See the
+"avg_daa Discriminator" section below.
+
+**Output discipline.** The `reasoning` field MUST end with `→ <category>` and that category MUST equal the `usage_category` field. Never conclude `→ trading` (or oracle / bridge / etc.) and then output `usage_category="other"`. If you cannot pick a specific category from the path, conclude `→ other` explicitly.
 
 ## DECISION PATHS (follow in order, stop at first match)
+
+### PATH 0 — Identity Gate  (RUN FIRST, ALWAYS)
+Before evaluating any other path, evaluate identity:
+
+  IF source_verified=True OR github.has_valid_repo=true:
+    → This contract has confirmed protocol identity. You MUST classify by trace content,
+      verified name, or repository ownership. PATH G1 / G2 / G3 trading defaults DO NOT apply.
+      "PRIVATE callers" alone is NOT grounds for `trading` when identity is confirmed.
+    → Proceed to PATH A (verified) or PATH B (proxy) and continue down the list.
+    → Exception: confirmed-identity contracts whose dominant trace activity is automated LP
+      management (CLPool/CLGauge/NonfungiblePositionManager mint/burn/collect) ARE `trading`,
+      even with confirmed identity. This single exception applies — no other identity-confirmed
+      contract may be classified `trading` based on caller diversity alone.
+    → When `github.has_valid_repo=true`, the linked repository's organization or contract name
+      pattern (e.g. `TransitSwapRouterV5` → transit-finance, `keystone-*` → keystonehq) is a
+      strong owner-project signal. Use it to assert protocol_likely=true.
+
+  IF source_verified=False AND github.has_valid_repo=False:
+    → No confirmed identity. PATH G1 / G2 / G3 caller-based trading defaults apply normally.
 
 ### PATH A — Verified + Named Contract
 IF source_verified=True AND blockscout_name != "unknown":
@@ -369,6 +400,14 @@ IF source_verified=True AND blockscout_name != "unknown":
       Rango*, RangoDiamond → bridge  (bridge aggregator, not dex)
       *DVN, *Dvn → cc_communication  (LayerZero verifier network)
       MayanSwift*, Mayan*Bridge → bridge
+      Socket*, SocketGateway, SocketBridge → bridge
+      OffchainAggregator, AccessControlledOffchainAggregator, *EACAggregator* → oracle  (Chainlink data feed)
+      OpenOceanSwapModule, OpenOcean*Module → nft_marketplace  (Seaport-bound; classify by host protocol)
+      ConditionalTokens, CTFExchange, NegRiskAdapter → prediction_markets  (Polymarket / Omen pattern)
+      IdRegistry, NameRegistry, *Registrar (Farcaster, ENS, Lens) → identity
+      *Factory, *Deployer, *Creator (deploys other contracts via CREATE/CREATE2) → developer_tools
+        (the factory's role is deployment infra; do not inherit category from what it deploys)
+      TransparentUpgradeableProxy, ERC1967Proxy, ProxyAdmin (when bs_name is exactly that) → developer_tools
       *Router without clear DEX context → examine trace, do NOT default to dex
   → Stablecoin token check (W6): if the contract name is a distribution/claim mechanism
     (Claim, DiamondClaim, Distributor, Airdrop, Vesting) AND traces show transfers of known
@@ -427,24 +466,37 @@ IF trace contains ONLY STATICCALL/SLOAD ops AND calls are exclusively slot0/pric
     Searchers call AMM pool slot0 across many different pools to compare prices
 
 ### PATH O — Oracle Infrastructure
-IF "Oracle function calls detected" list is non-empty:
-  → This contract calls or delegates to oracle-specific functions (storkPublicKey, latestRoundData,
-    updatePriceFeed, parsePriceFeedUpdates, etc.). These functions only exist on oracle infrastructure.
-  → usage_category = oracle
+IF "Oracle function calls detected" list is non-empty AND those functions are central
+   (entry method OR matched in the majority of traces):
+  → Oracle-specific functions: storkPublicKey, latestRoundData, latestAnswer, updatePriceFeed,
+    updatePrices, postPrices, parsePriceFeedUpdates, transmit, fulfillOracleRequest, fulfillOracleRequest2.
+    A contract whose entry method is updatePrices/updatePriceFeed is an oracle pusher — classify oracle
+    even when callers are PRIVATE (single operator) or PUBLIC (decentralized network).
+  → usage_category = oracle  (this is sticky — once chosen, do not fall back to "other" later in reasoning)
   → Name: "[Protocol]Oracle", "[Protocol]PriceFeed", or "[Protocol]OracleProxy" depending on trace depth.
-    If DELEGATECALL to oracle → it IS the oracle (proxy). If CALL → it USES the oracle (consumer — fall through if only 1 oracle call and other DeFi context dominates).
-  → Override even for unverified contracts with PRIVATE callers — a single-operator oracle updater
+    If DELEGATECALL to oracle → it IS the oracle (proxy). If CALL → it USES the oracle (consumer).
+    Chainlink Operator contracts (calling fulfillOracleRequest/transmit) are oracle, not their host protocol.
+  → Override for unverified contracts with PRIVATE callers — a single-operator oracle updater
     is still oracle infrastructure, not a trading bot.
+  → Soft exception: if a contract calls one oracle getter incidentally (e.g. latestAnswer once)
+    but the dominant activity is large stablecoin transfers or DEX swaps, classify by the dominant
+    activity instead. Do not treat one oracle getter as conclusive evidence of oracle identity.
 
 ### PATH G1 — Private Callers (PRIVATE diversity ≤20%)
 IF caller_diversity_label = "PRIVATE" AND no prior path matched:
   **CRITICAL: This path applies even when traces are raw opcodes only and identity is unknown.
   Raw-opcode traces + PRIVATE callers + no identity IS the trading bot signature — intentionally unverified.
   Do NOT skip to G0 because traces are unreadable. If the label says PRIVATE, use G1.**
-  EXCEPTION — verified contracts: do NOT apply trading defaults. Verified contracts with private
-    callers are almost always protocol infrastructure (vault, liquidator, position manager), not MEV bots.
+  EXCEPTION — verified contracts OR `github.has_valid_repo=true`: do NOT apply trading defaults.
+    Contracts with confirmed identity (verified source OR linked GitHub repo) and private callers
+    are almost always protocol infrastructure (vault, liquidator, position manager), not MEV bots.
     Classify by trace content; only assign trading if traces explicitly show MEV patterns (raw slot0
     reads across many pools, failed-tx-heavy swaps).
+  EXCEPTION-TO-EXCEPTION: verified or github-linked contracts that interact directly with
+    LP infrastructure (CLPool/CLGauge/NonfungiblePositionManager, Aerodrome/Velodrome rebalancers)
+    via mint/burn/collect/_collect calls ARE automated trading strategies, not protocol infra.
+    Classify trading even when verified. Name "[Protocol]Rebalancer" or "[Asset]PositionManager"
+    using the underlying-asset rule from §contract_name.
   VERIFIED + DEX router calls: prefer dex — settlement or fulfillment infrastructure. Use trace entry
     function to name it (e.g. "RFQSettlement", "FulfillHelper"). Exception: very low success_rate or
     clear failed-tx patterns → trading still possible.
@@ -468,6 +520,8 @@ IF caller_diversity_label = "PRIVATE" AND no prior path matched:
 IF caller_diversity_label = "KEEPER" AND no prior path matched:
   EXCEPTION — verified contracts with named protocol interactions: classify by trace content.
     Verified keeper contracts are typically protocol infrastructure (liquidators, settlement, distributors).
+  EXCEPTION-TO-EXCEPTION: verified contracts whose dominant trace activity is automated LP
+    management (CLPool/CLGauge/NonfungiblePositionManager mint/burn/collect) ARE trading.
   VERIFIED + DEX router calls: KEEPER + verified + DEX router = DEX settlement/aggregation signature
     (1inch resolvers, CoW solvers, RFQ market makers are all KEEPER callers). Prefer dex.
   VERIFIED + bridge calls: prefer bridge or cc_communication.
@@ -492,16 +546,54 @@ IF caller_diversity_label = "KEEPER" AND no prior path matched:
 ### PATH G3 — Public Callers (PUBLIC diversity ≥80%)
 IF caller_diversity_label = "PUBLIC" AND no prior path matched:
   → Many different callers — public-facing. Classify by what the contract does.
-  - Known DEX interactions (swap events, pool calls) → dex
+  - **Stablecoin name match**: novel_tokens or bs_token_transfers token name/symbol contains
+    USD / Stable / DAI / USDT / USDC / USDM / BUSD / TUSD / FRAX / LUSD AND that token is the
+    primary asset moved → stablecoin. Token-name pattern wins as primary signal here.
+  - **Low success_rate override**: success_rate < 60% with DEX router or pool-swap traces →
+    public arbitrage / sandwich pattern → trading, "MEVBot" or "ArbitrageBot". Many public callers
+    competing and failing is the MEV signature; do NOT classify as dex when most txs revert.
+  - Known DEX interactions (swap events, pool calls) AND success_rate ≥ 60% AND avg_daa qualifies
+    as PUBLIC (see §avg_daa Discriminator below) → dex
   - Named STATIC calls to EACAggregatorProxy/Chainlink feeds → oracle consumer
   - Pool-internal math (computeSwapStep, getSqrtRatioAtTick as INTERNAL nodes) → dex
   - Calls to LayerZero, Wormhole, Axelar, or other cross-chain messaging endpoints → cc_communication
+  - Calls to Relay*, Stargate, Connext, Synapse, Across, deBridge → bridge
   - Calls to VRF (Chainlink VRF, Pyth randomness) → gaming
+  - Airdrop/Claim/Distributor/Vesting/Rewards/Points patterns with broad user base AND
+    no stablecoin-name match above → airdrop
+  - Stablecoin distribution (FiatToken/USDC/Tether transfers via Claim/Airdrop/Vesting patterns) → stablecoin
   - Social/check-in pattern (simple state writes per user, no DeFi signals) → community
   - Calls to `liquidate`, `auction`, `seize`, or `settle` on lending/perp contracts → lending or derivative
   - No DeFi signals: classify by semantic meaning of the contract name. Do NOT default to other for a specific name.
   - Truly ambiguous name AND no usable signals → other
   - IMPORTANT: Named contracts in the DEEP trace are downstream callees — do NOT classify this contract as CLPool just because CLPool appears in the trace.
+
+### avg_daa Discriminator — Trading vs DEXAggregator
+The single strongest signal separating private trading bots from public DEX infrastructure is
+**absolute avg_daa relative to chain_median_daa**. Apply these gates BEFORE picking dex/DEXAggregator:
+
+  HIGH-DAA (avg_daa ≥ chain_median_daa AND avg_daa ≥ 50):
+    → Public infrastructure. Many independent users. Cannot be a private trading bot regardless
+       of how trading-shaped the traces look. Even if the contract calls DEX routers and swaps
+       look bot-like, high public usage rules out trading. Classify dex / bridge / oracle / etc.
+       by trace content. Override "trading bot" heuristics from G1/G2.
+
+  LOW-DAA (avg_daa < max(chain_median_daa × 0.05, 3)):
+    → Private operator(s). Cannot be DEXAggregator regardless of trace shape. A real DEX
+       aggregator must have a public user base.
+    → If success_rate < 90% AND DEX/swap activity → trading (MEVBot / ArbitrageBot).
+    → If success_rate ≥ 90% AND DEX/swap activity → trading (StrategyExecutor / [Protocol]Rebalancer).
+    → "DEXAggregator" is INVALID at this DAA level unless caller_diversity_label is reliably
+       PUBLIC and you can confirm the callers are real EOAs (not admin/keeper EOAs cycling addresses).
+
+  MID-DAA (between LOW and HIGH thresholds):
+    → Examine caller_diversity_label and success_rate.
+    → KEEPER-ish + low success_rate + DEX swaps → trading (private strategy with rotating ops).
+    → PUBLIC-ish + high success_rate + diverse trace counterparties → dex / aggregator.
+    → When in doubt, prefer trading. DEXAggregator is a strong claim; require strong evidence.
+
+When picking the name "DEXAggregator", you MUST justify it by citing avg_daa ≥ chain_median_daa
+in the reasoning. If you cannot, use "StrategyExecutor" or "MEVBot" instead.
 
 ### PATH G0 — No Caller Data
 IF caller_diversity_label = "UNKNOWN":
@@ -521,12 +613,34 @@ IF caller_diversity_label = "UNKNOWN":
 
 ## contract_name (max 50 chars)
 Name what the contract IS or DOES — use protocol-aware names when traces reveal them.
-- PATH A: use exact Blockscout name
-- PATH B: delegate target name + "Proxy" suffix
-- Unverified trading contracts: describe the behavior — "MEVBot", "ArbitrageBot", "PriceScanner", "[Protocol]CLRebalancer", "[Protocol][Token]LPManager"
-- Unverified non-trading: derive from trace interactions — "OracleConsumer", "DEXAggregator", "BridgeCaller"
-- When identity is truly unknown: "AmbiguousContract"
-- NEVER use generic filler: "UnverifiedProxy", "UnverifiedContract", "Unknown", "MinimalProxy"
+
+Naming source priority (high to low):
+1. Verified Blockscout name (PATH A) or delegate-target name (PATH B).
+2. Named contracts in traces — `named_contracts_in_traces` is the strongest external-identity signal.
+   Build descriptive names from these: "[Protocol]Manager", "[Protocol]Rebalancer", "[Protocol]Adapter".
+   For LP managers, prefer the underlying-asset name over the AMM venue when a major asset (USDC/USDT/DAI/FiatToken) is present:
+   "FiatTokenPositionManager" beats "AerodromeCLRebalancer" if the position is USDC-denominated.
+3. Novel-protocol tokens (`novel_tokens` list) — only when traces lack named protocol contracts.
+4. Behavioral name from caller pattern — "MEVBot", "ArbitrageBot", "PriceScanner", "StrategyExecutor".
+
+Constraints:
+- Token transfers from Blockscout (`bs_token_transfers`) are weaker evidence than trace contract names.
+  Do NOT name a contract after a token in `bs_token_transfers` if `named_contracts_in_traces` is non-empty.
+- Forbid composites that fuse a token symbol with a trace-derived contract type. Examples:
+  "UAVPoolManager" (UAV from token + PoolManager from trace) is WRONG — pick one source.
+  Use "PoolManager" (trace identity) or, if the underlying asset is the dominant signal,
+  "[Asset]PositionManager". Never glue them.
+- Verified contract with a generic standard-implementation name (ERC20, ERC721, OptimismMintableERC20,
+  StandardToken): the verified name is uninformative — derive the real name from the token name in
+  bs_token_transfers (e.g. "Autonolas" not "OptimismMintableERC20").
+- Unverified trading contracts: describe the behavior — "MEVBot", "ArbitrageBot", "PriceScanner",
+  "[Protocol]CLRebalancer", "[Protocol][Token]LPManager".
+- Unverified non-trading: derive from trace interactions — "OracleConsumer", "DEXAggregator", "BridgeCaller".
+- PATH E (EIP-1167 clones, empty trace): name "CloneExecutor" by default — do not say "StrategyExecutor"
+  unless the caller pattern matches G1.
+- Use "AmbiguousContract" ONLY when bs_name=unknown AND novel_tokens=empty AND named_contracts_in_traces=empty AND log_signals all false.
+  Otherwise produce a descriptive name.
+- NEVER use generic filler: "UnverifiedProxy", "UnverifiedContract", "Unknown", "MinimalProxy".
 
 ---
 
@@ -807,7 +921,13 @@ async def classify_contract(
     novel_tokens   = [t for t in dominant_all if t.lower() not in _COMMON_TOKENS][:5]
     common_tokens  = [t for t in dominant_all if t.lower() in _COMMON_TOKENS][:4]
 
-    # Augment with Blockscout token-transfer names (higher reliability than trace decoding).
+    # Augment novel_tokens with Blockscout token-transfer names — but gate on trace match.
+    # P2 fix: BS token transfers (often unrelated proxy/forwarder activity) used to dominate
+    # naming for simple proxies. Now we only promote a BS token to novel_tokens when it
+    # also appears in the trace-decoded contract names, OR when traces are entirely empty
+    # (no competing trace identity to override). Full bs_token_display still passes through
+    # to the prompt as context.
+    trace_token_names_lower = {n.lower() for n in token_trace_counts.keys()}
     bs_token_display: list[str] = []
     if token_transfers:
         for tt in token_transfers:
@@ -821,6 +941,14 @@ async def classify_contract(
                 label_str = f"{label_str} [{tok_type}]"
             bs_token_display.append(label_str)
             nl = name.lower()
+            sl = sym.lower()
+            trace_match = (
+                nl in trace_token_names_lower
+                or (sl and sl in trace_token_names_lower)
+                or not trace_token_names_lower
+            )
+            if not trace_match:
+                continue  # keep in bs_token_display, but don't promote to novel_tokens
             if nl not in _COMMON_TOKENS:
                 if name not in novel_tokens:
                     novel_tokens.append(name)
@@ -922,27 +1050,36 @@ Category hints from events: {', '.join(log_signals['category_hints']) or 'none'}
 ## Select usage_category (pick one of these IDs):
 {categories['context']}"""
 
+    # property_ordering forces reasoning to be generated FIRST. Without this, Flash
+    # commits to usage_category before deriving the path conclusion and hedges to
+    # "other" while reasoning subsequently lands on a specific category — produces
+    # internal contradictions seen in eval (80/127 rows in the 2026-04-27 baseline).
+    # enum on usage_category prevents the model from emitting categories outside the
+    # OLI valid_ids set (otherwise the post-process at the bottom of this fn rewrites
+    # them to fallback_id, which compounds the contradiction).
     response_schema = genai_types.Schema(
         type=genai_types.Type.OBJECT,
         properties={
+            "reasoning": genai_types.Schema(
+                type=genai_types.Type.STRING,
+                description="Required format: 'PATH X[subpath]: signal=val, signal=val → category. Ruled out Y because Z.' Always name the path taken. Always state what was ruled out. usage_category MUST equal the category named after the arrow.",
+            ),
             "contract_name": genai_types.Schema(
                 type=genai_types.Type.STRING,
                 description="Short descriptive name for the contract (max 50 chars)",
             ),
             "usage_category": genai_types.Schema(
                 type=genai_types.Type.STRING,
-                description="OLI usage category ID — must be one of the listed category IDs",
+                enum=valid_ids,
+                description="OLI usage category ID — must equal the conclusion in reasoning.",
             ),
             "confidence": genai_types.Schema(
                 type=genai_types.Type.NUMBER,
                 description="Confidence score 0.0–1.0",
             ),
-            "reasoning": genai_types.Schema(
-                type=genai_types.Type.STRING,
-                description="Required format: 'PATH X[subpath]: signal=val, signal=val → category. Ruled out Y because Z.' Always name the path taken. Always state what was ruled out. No filler, fragments OK.",
-            ),
         },
-        required=["contract_name", "usage_category"],
+        required=["reasoning", "contract_name", "usage_category"],
+        property_ordering=["reasoning", "contract_name", "usage_category", "confidence"],
     )
 
     try:
@@ -990,32 +1127,32 @@ Category hints from events: {', '.join(log_signals['category_hints']) or 'none'}
                     args['usage_category'] = fallback_id
                 args.setdefault('confidence', 0.5)
                 args.setdefault('reasoning', '')
-                # Attach novel_tokens so sentinel can use them without re-computing
-                args['novel_tokens'] = novel_tokens
-                # TODO(contract_label_features): extend return dict with pre-computed signals so
-                # automated_labeler.py can write them to contract_label_features without re-computing.
-                # Add to args before return:
-                #   args['common_tokens']              = common_tokens
-                #   args['matched_routers']            = list(matched_routers)
-                #   args['matched_dex_pools']          = list(matched_dex_pools)
-                #   args['calls_into_dex_pool_swap']   = calls_into_dex_pool_swap
-                #   args['matched_lending']            = list(matched_lending)
-                #   args['matched_staking']            = list(matched_staking)
-                #   args['matched_bridges']            = list(matched_bridges)
-                #   args['matched_oracle_fns']         = list(matched_oracle_fns)
-                #   args['delegates_to']               = this_contract_delegates_to or None
-                #   args['raw_delegate']               = this_contract_raw_delegate
-                #   args['all_traces_empty']           = all_traces_empty
-                #   args['traces_only_raw_opcodes']    = traces_only_raw_opcodes
-                #   args['named_contracts_in_traces']  = sorted(named_contracts_in_traces)
-                #   args['caller_diversity_pct']       = caller_diversity_pct
-                #   args['caller_diversity_label']     = caller_diversity_label
-                #   args['unique_callers']             = unique_callers
-                #   args['total_traces_sampled']       = total_traces_with_caller
-                #   args['log_signals']                = log_signals   (full decode_log_signals dict)
-                #   args['sentinel_fired']             = False          (True in sentinel fast-path)
-                # Sentinel fast-path (see lines ~1060–1090) also needs sentinel_fired=True added.
-                # Fallback return (see lines ~1006–1012) needs all fields with safe empty defaults.
+                # Attach pre-computed signals so automated_labeler can write contract_label_features
+                # without re-computing. Keep keys aligned with the schema in
+                # docs/contract_label_features_schema.md / db_migrations/001_contract_label_features.sql.
+                args['novel_tokens']               = novel_tokens
+                args['common_tokens']              = common_tokens
+                args['bs_token_transfers']         = list(token_transfers or [])
+                args['matched_routers']            = list(matched_routers)
+                args['matched_dex_pools']          = list(matched_dex_pools)
+                args['calls_into_dex_pool_swap']   = bool(calls_into_dex_pool_swap)
+                args['matched_lending']            = list(matched_lending)
+                args['matched_staking']            = list(matched_staking)
+                args['matched_bridges']            = list(matched_bridges)
+                args['matched_oracle_fns']         = list(matched_oracle_fns)
+                args['delegates_to']               = this_contract_delegates_to or None
+                args['raw_delegate']               = bool(this_contract_raw_delegate)
+                args['all_traces_empty']           = bool(all_traces_empty)
+                args['traces_only_raw_opcodes']    = bool(traces_only_raw_opcodes)
+                args['named_contracts_in_traces']  = sorted(named_contracts_in_traces)
+                args['caller_diversity_pct']       = caller_diversity_pct
+                args['caller_diversity_label']     = caller_diversity_label
+                args['unique_callers']             = unique_callers
+                args['total_traces_sampled']       = total_traces_with_caller
+                args['log_signals']                = log_signals
+                args['sentinel_fired']             = False
+                args['sentinel_category']          = None
+                args['ai_model']                   = GEMINI_MODEL
                 return args
             logger.warning(f"[Classifier] Could not parse Gemini response for {address}: {raw[:120]!r}")
 
@@ -1027,14 +1164,36 @@ Category hints from events: {', '.join(log_signals['category_hints']) or 'none'}
     except Exception as e:
         logger.error(f"[Classifier] Gemini API error for {address}: {e}")
 
-    # TODO(contract_label_features): add all pre-computed signal keys with safe empty defaults
-    # to this fallback return so contract_label_features always gets a complete row even on failure.
+    # Fallback path — Gemini failed. Still return a complete dict so the feature row writer
+    # can persist what we know (signals we computed locally before the API call).
     return {
         'contract_name': bs_name if bs_name != 'unknown' else f"Contract-{address[:8]}",
         'usage_category': fallback_id,
         'confidence': 0.0,
         'reasoning': 'Classification failed — using fallback.',
         'novel_tokens': novel_tokens,
+        'common_tokens': common_tokens,
+        'bs_token_transfers': list(token_transfers or []),
+        'matched_routers': list(matched_routers),
+        'matched_dex_pools': list(matched_dex_pools),
+        'calls_into_dex_pool_swap': bool(calls_into_dex_pool_swap),
+        'matched_lending': list(matched_lending),
+        'matched_staking': list(matched_staking),
+        'matched_bridges': list(matched_bridges),
+        'matched_oracle_fns': list(matched_oracle_fns),
+        'delegates_to': this_contract_delegates_to or None,
+        'raw_delegate': bool(this_contract_raw_delegate),
+        'all_traces_empty': bool(all_traces_empty),
+        'traces_only_raw_opcodes': bool(traces_only_raw_opcodes),
+        'named_contracts_in_traces': sorted(named_contracts_in_traces),
+        'caller_diversity_pct': caller_diversity_pct,
+        'caller_diversity_label': caller_diversity_label,
+        'unique_callers': unique_callers,
+        'total_traces_sampled': total_traces_with_caller,
+        'log_signals': log_signals,
+        'sentinel_fired': False,
+        'sentinel_category': None,
+        'ai_model': GEMINI_MODEL,
     }
 
 

--- a/backend/labeling/automated_labeler.py
+++ b/backend/labeling/automated_labeler.py
@@ -893,6 +893,27 @@ async def run_pipeline(args):
         rows = build_attestation_rows(final, valid_ids)
     json_path, csv_path = write_output(rows, args.output_dir)
 
+    # TODO(contract_label_features): write all classified contracts (including low-confidence ones
+    # below the 0.5 attestation threshold) to public.contract_label_features via a new
+    # db_connector.upsert_contract_label_features() method. This must happen BEFORE OLI attestation
+    # so every run is captured regardless of whether the contract clears the confidence threshold.
+    #
+    # Build feature rows from `final` (the list of enriched+labeled contract dicts):
+    #
+    #   feature_rows = [_build_feature_row(c) for c in final if c.get('label')]
+    #   db_connector.upsert_contract_label_features(feature_rows)
+    #
+    # _build_feature_row(contract) pulls from:
+    #   contract['blockscout']      → is_verified, is_proxy, impl_address, impl_name, impl_verified, blockscout_name
+    #   contract['github']          → has_github_repo, github_repo_count
+    #   contract['metrics']         → txcount, gas_eth, avg_daa, avg_gas_per_tx, rel_cost, success_rate, day_range
+    #   contract['token_transfers'] → bs_token_transfers (raw jsonb)
+    #   contract['label']           → all ai_* columns + all pre-computed signal columns
+    #                                 (requires the TODO in ai_classifier.py to be done first)
+    #   _is_protocol_likely(...)    → ai_owner_project_likely (bool)
+    #
+    # See docs/contract_label_features_schema.md for the full column list.
+
     # Summary
     by_category: dict[str, int] = {}
     for r in rows:

--- a/backend/labeling/automated_labeler.py
+++ b/backend/labeling/automated_labeler.py
@@ -665,6 +665,99 @@ def build_attestation_rows_v2(labeled_contracts: list[dict], valid_ids: list[str
     return rows
 
 
+def _build_feature_row(contract: dict) -> dict:
+    """Flatten enriched + labeled contract dict into a contract_label_features row.
+
+    Schema: docs/contract_label_features_schema.md
+    Required preconditions: classify_contract() has populated contract['label'] with the
+    extended return dict (the 22 pre-computed signal keys).
+    """
+    bs = contract.get('blockscout', {}) or {}
+    gh = contract.get('github', {}) or {}
+    m  = contract.get('metrics', {}) or {}
+    label = contract.get('label', {}) or {}
+    log_signals = label.get('log_signals', {}) or {}
+
+    txcount = m.get('txcount') or 0
+    avg_daa = m.get('avg_daa') or 0
+    daa_ratio = (avg_daa / txcount * 100) if txcount else 0
+
+    # ai_owner_project_likely: re-run sentinel so the feature store records the same flag
+    # the labeler would later attest as 'protocol-contract-likely'.
+    likely = _is_protocol_likely(label, bs, {**log_signals,
+                                              'has_valid_repo': gh.get('has_valid_repo', False)}, m)
+
+    impl_addr = bs.get('impl_address')
+    if isinstance(impl_addr, str) and impl_addr.startswith('0x'):
+        impl_addr_db = impl_addr.lower().replace('0x', '\\x')
+    else:
+        impl_addr_db = None
+
+    return {
+        # Identity
+        'address':            contract['address'],
+        'origin_key':         contract['origin_key'],
+        'labeled_at':         datetime.utcnow(),
+        'blockscout_name':    bs.get('contract_name'),
+        'is_verified':        bool(bs.get('is_verified', False)),
+        'is_proxy':           bool(bs.get('is_proxy', False)),
+        'impl_address':       impl_addr_db,
+        'impl_name':          bs.get('impl_name'),
+        'impl_verified':      bool(bs.get('impl_verified', False)),
+        'has_github_repo':    bool(gh.get('has_valid_repo', False)),
+        'github_repo_count':  int(gh.get('repo_count', 0)),
+        # Activity
+        'metric_day_range':   m.get('day_range'),
+        'txcount':            txcount,
+        'gas_eth':             m.get('gas_eth'),
+        'avg_daa':             avg_daa,
+        'avg_gas_per_tx':      m.get('avg_gas_per_tx'),
+        'rel_cost':            m.get('rel_cost'),
+        'success_rate':        m.get('success_rate'),
+        'daa_ratio':           daa_ratio,
+        # Caller diversity
+        'caller_diversity_pct':   label.get('caller_diversity_pct'),
+        'caller_diversity_label': label.get('caller_diversity_label'),
+        'unique_callers':         label.get('unique_callers'),
+        'total_traces_sampled':   label.get('total_traces_sampled'),
+        # Trace signals
+        'novel_tokens':              label.get('novel_tokens') or [],
+        'common_tokens':             label.get('common_tokens') or [],
+        'bs_token_transfers':        label.get('bs_token_transfers') or [],
+        'matched_routers':           label.get('matched_routers') or [],
+        'matched_dex_pools':         label.get('matched_dex_pools') or [],
+        'calls_into_dex_pool_swap':  bool(label.get('calls_into_dex_pool_swap', False)),
+        'matched_lending':           label.get('matched_lending') or [],
+        'matched_staking':           label.get('matched_staking') or [],
+        'matched_bridges':           label.get('matched_bridges') or [],
+        'matched_oracle_fns':        label.get('matched_oracle_fns') or [],
+        'delegates_to':              label.get('delegates_to'),
+        'raw_delegate':              bool(label.get('raw_delegate', False)),
+        'all_traces_empty':          bool(label.get('all_traces_empty', False)),
+        'traces_only_raw_opcodes':   bool(label.get('traces_only_raw_opcodes', False)),
+        'named_contracts_in_traces': label.get('named_contracts_in_traces') or [],
+        # Log signals
+        'log_has_access_control':  bool(log_signals.get('has_access_control', False)),
+        'log_has_token_transfers': bool(log_signals.get('has_token_transfers', False)),
+        'log_has_swaps':           bool(log_signals.get('has_swaps', False)),
+        'log_has_bridge_events':   bool(log_signals.get('has_bridge_events', False)),
+        'log_has_erc4337':         bool(log_signals.get('has_erc4337', False)),
+        'log_has_staking':         bool(log_signals.get('has_staking', False)),
+        'log_has_governance':      bool(log_signals.get('has_governance', False)),
+        'log_category_hints':      log_signals.get('category_hints') or [],
+        'log_top_events':          log_signals.get('summary'),
+        # AI output
+        'ai_contract_name':        label.get('contract_name'),
+        'ai_usage_category':       label.get('usage_category'),
+        'ai_confidence':           label.get('confidence'),
+        'ai_reasoning':            label.get('reasoning'),
+        'ai_model':                label.get('ai_model'),
+        'ai_owner_project_likely': bool(likely),
+        'sentinel_fired':          bool(label.get('sentinel_fired', False)),
+        'sentinel_category':       label.get('sentinel_category'),
+    }
+
+
 def write_output(rows: list[dict], output_dir: str, prefix: str = "labeled_contracts") -> tuple[str, str]:
     """Write JSON and CSV attestation files. Returns (json_path, csv_path)."""
     Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -772,6 +865,7 @@ def _write_attested_to_airtable(rows: list[dict]) -> None:
             '_comment', '_source', 'attester', 'is_protocol_contract_likely',
             'confidence', 'txcount', 'gas_eth', 'avg_daa', 'rel_cost',
             'github_found',
+            'day_range', 'avg_gas_per_tx', 'success_rate',
         }
         df = df.drop(columns=[c for c in df.columns if c not in AIRTABLE_COLS])
 
@@ -893,26 +987,18 @@ async def run_pipeline(args):
         rows = build_attestation_rows(final, valid_ids)
     json_path, csv_path = write_output(rows, args.output_dir)
 
-    # TODO(contract_label_features): write all classified contracts (including low-confidence ones
-    # below the 0.5 attestation threshold) to public.contract_label_features via a new
-    # db_connector.upsert_contract_label_features() method. This must happen BEFORE OLI attestation
-    # so every run is captured regardless of whether the contract clears the confidence threshold.
-    #
-    # Build feature rows from `final` (the list of enriched+labeled contract dicts):
-    #
-    #   feature_rows = [_build_feature_row(c) for c in final if c.get('label')]
-    #   db_connector.upsert_contract_label_features(feature_rows)
-    #
-    # _build_feature_row(contract) pulls from:
-    #   contract['blockscout']      → is_verified, is_proxy, impl_address, impl_name, impl_verified, blockscout_name
-    #   contract['github']          → has_github_repo, github_repo_count
-    #   contract['metrics']         → txcount, gas_eth, avg_daa, avg_gas_per_tx, rel_cost, success_rate, day_range
-    #   contract['token_transfers'] → bs_token_transfers (raw jsonb)
-    #   contract['label']           → all ai_* columns + all pre-computed signal columns
-    #                                 (requires the TODO in ai_classifier.py to be done first)
-    #   _is_protocol_likely(...)    → ai_owner_project_likely (bool)
-    #
-    # See docs/contract_label_features_schema.md for the full column list.
+    # Persist every labeled contract to contract_label_features (incl. sub-threshold rows).
+    # Runs BEFORE Airtable / OLI flow so each run is captured regardless of whether the
+    # contract clears the confidence threshold for attestation.
+    if _HAS_DB:
+        try:
+            feature_rows = [_build_feature_row(c) for c in final if c.get('label')]
+            if feature_rows:
+                db = DbConnector()
+                n = db.upsert_contract_label_features(feature_rows)
+                logger.info(f"[contract_label_features] upserted {n} rows")
+        except Exception as e:
+            logger.error(f"[contract_label_features] write failed (non-fatal): {e}")
 
     # Summary
     by_category: dict[str, int] = {}

--- a/backend/labeling/eval/README.md
+++ b/backend/labeling/eval/README.md
@@ -1,0 +1,74 @@
+# Classifier Self-Critique Eval
+
+Re-runs `ai_classifier.classify_contract()` on rows humans corrected, then asks
+`gemini-2.5-pro` (the meta-evaluator) to diagnose what went wrong and propose
+concrete edits to `_SYSTEM_INSTRUCTION`.
+
+## Files
+
+- `context_cache.py` — caches on-chain context (Blockscout/Tenderly/GitHub) per `(address, origin_key)` so prompt iterations don't re-spend API credits. Cache lives at `backend/local/eval_cache/`.
+- `re_eval_prompt.py` — meta-evaluator system prompt + JSON response schema.
+- `eval_human_corrections.py` — orchestrator. Loads dump, filters to rows with human corrections, reclassifies, meta-evals, persists JSONL + markdown report.
+
+## Quickstart
+
+Smoke test (no meta calls, 3 rows):
+
+```bash
+python backend/labeling/eval/eval_human_corrections.py \
+    --run-id smoke --limit 3 --skip-meta
+```
+
+Full run on every row with a human correction:
+
+```bash
+python backend/labeling/eval/eval_human_corrections.py \
+    --run-id 2026-04-27_pass1
+```
+
+Force-refresh on-chain context (skip cache):
+
+```bash
+python backend/labeling/eval/eval_human_corrections.py \
+    --run-id 2026-04-27_refresh --refresh
+```
+
+Bulk-warm cache only:
+
+```bash
+python backend/labeling/eval/context_cache.py --limit 0
+```
+
+## Outputs
+
+- `backend/local/eval_results/<run_id>/per_row.jsonl` — one JSON object per evaluated row containing `{address, origin_key, ground_truth, ai_original, ai_rerun, raw_signals, meta_eval, ts}`.
+- `backend/local/eval_results/<run_id>/report.md` — aggregated patterns + ranked prompt-edit proposals + per-row diff table.
+
+## Ground-truth filter
+
+A row is evaluated only when at least one of these is set:
+
+- `human_contract_name`
+- `human_usage_category` (slug)
+- `gtp_owner_project_confirmed=True` AND `owner_project_linked` non-empty
+- `gtp_no_owner_project=True`
+- `temp_owner_project` non-empty
+- `human_comment` non-empty
+
+## Future RL hook
+
+Per-row JSONL is shaped close to (state, action, reward) for offline RL:
+
+- **state** = `ground_truth` + `raw_signals`
+- **action** = `ai_rerun`
+- **reward signal** = `meta_eval.severity` + per-field correctness comparison
+
+Once `contract_label_review` is populated, swap the dump loader for a SQL
+query against `contract_label_review JOIN contract_label_features` — no other
+structural changes needed.
+
+## Env required
+
+- `GEMINI_API_KEY` — used for both classifier (Flash) and meta-evaluator (Pro)
+- `BLOCKSCOUT_API_KEYS`, `TENDERLY_ACCESS_KEY`, GitHub token — only needed on cache miss
+- DB env vars (`DB_*`) — needed only on cache miss (for chain median DAA + metrics)

--- a/backend/labeling/eval/context_cache.py
+++ b/backend/labeling/eval/context_cache.py
@@ -1,0 +1,275 @@
+"""On-chain context cache for the classifier eval loop.
+
+For each (address, origin_key) pair this module produces — and persists — the dict
+shape that `ai_classifier.classify_contract()` consumes:
+
+    {metrics, blockscout, github, traces, address_logs, token_transfers}
+
+Cache layout: backend/local/eval_cache/<origin_key>__<address_lower>.json
+
+Default: cache forever. Force re-fetch with --refresh on the bulk warmer or
+build_or_load(refresh=True) at call sites.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import ssl
+import sys
+from pathlib import Path
+from typing import Optional
+
+import aiohttp
+from dotenv import load_dotenv
+
+# ── Path setup mirrors automated_labeler.py ──────────────────────────────────
+_THIS_DIR = Path(__file__).resolve().parent              # …/backend/labeling/eval
+_LABELING_DIR = _THIS_DIR.parent                          # …/backend/labeling
+_BACKEND_DIR = _LABELING_DIR.parent                       # …/backend
+_REPO_ROOT = _BACKEND_DIR.parent                          # …/gtp-backend
+
+for _p in [str(_LABELING_DIR), str(_BACKEND_DIR)]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+load_dotenv(dotenv_path=_BACKEND_DIR / ".env", override=False)
+load_dotenv(dotenv_path=_REPO_ROOT / ".env", override=False)
+load_dotenv(override=False)
+
+from concurrent_contract_analyzer import (  # noqa: E402
+    BlockscoutAPI_Async,
+    GitHubAPI_Async,
+    TenderlyAPI_Async,
+    Config,
+)
+from automated_labeler import (  # noqa: E402
+    enrich_contract,
+    inject_chain_median_daa,
+    fetch_chain_median_daa,
+    _load_chain_config,
+    ORIGIN_KEY_TO_CHAIN_ID,
+)
+
+logger = logging.getLogger("eval.cache")
+
+CACHE_DIR = _BACKEND_DIR / "local" / "eval_cache"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _cache_path(address: str, origin_key: str) -> Path:
+    return CACHE_DIR / f"{origin_key}__{address.lower()}.json"
+
+
+def load_cached(address: str, origin_key: str) -> Optional[dict]:
+    p = _cache_path(address, origin_key)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except Exception as e:
+        logger.warning(f"cache read failed for {p}: {e}")
+        return None
+
+
+def save_cached(address: str, origin_key: str, ctx: dict) -> None:
+    p = _cache_path(address, origin_key)
+    p.write_text(json.dumps(ctx, indent=2, default=str))
+
+
+def _ssl_ctx():
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def _fetch_db_metrics(address: str, origin_key: str, days: int = 7) -> Optional[dict]:
+    """Pull this contract's metrics row from blockspace_fact_contract_level (last N days)."""
+    try:
+        from src.db_connector import DbConnector
+        db = DbConnector()
+        sql = f"""
+            SELECT
+                SUM(txcount)              AS txcount,
+                SUM(gas_fees_eth)         AS gas_eth,
+                AVG(daa)                  AS avg_daa,
+                AVG(success_rate)         AS success_rate
+            FROM public.blockspace_fact_contract_level
+            WHERE address = decode(replace(lower(:addr), '0x', ''), 'hex')
+              AND origin_key = :origin_key
+              AND date >= NOW() - INTERVAL '{days} days'
+        """
+        from sqlalchemy import text as sa_text
+        with db.engine.begin() as conn:
+            row = conn.execute(sa_text(sql), {"addr": address, "origin_key": origin_key}).fetchone()
+        if not row or not row[0]:
+            return None
+        txcount = int(row[0])
+        gas_eth = float(row[1] or 0)
+        return {
+            "txcount": txcount,
+            "gas_eth": gas_eth,
+            "avg_daa": float(row[2] or 0),
+            "rel_cost": 0.0,  # not load-bearing for re-eval; classifier uses it as a heuristic
+            "avg_gas_per_tx": round(gas_eth / txcount, 8) if txcount else 0,
+            "day_range": days,
+            "success_rate": float(row[3]) if row[3] is not None else None,
+        }
+    except Exception as e:
+        logger.warning(f"DB metrics fetch failed for {address}/{origin_key}: {e}")
+        return None
+
+
+def _seed_metrics_from_dump_row(row: dict, days: int = 7) -> dict:
+    """Fallback: build a plausible metrics dict from the validation-dump row when DB read fails."""
+    txcount = int(row.get("txcount") or 0)
+    gas_eth = 0.0  # not in dump
+    avg_daa = float(row.get("avg_daa") or 0)
+    rel_cost = float(row.get("rel_cost") or 0)
+    sr = row.get("success_rate")
+    try:
+        sr = float(sr) if sr not in (None, "") else None
+    except (TypeError, ValueError):
+        sr = None
+    return {
+        "txcount": txcount,
+        "gas_eth": gas_eth,
+        "avg_daa": avg_daa,
+        "rel_cost": rel_cost,
+        "avg_gas_per_tx": 0.0,
+        "day_range": days,
+        "success_rate": sr,
+    }
+
+
+async def _enrich_one(
+    contract: dict,
+    session: aiohttp.ClientSession,
+    enrich_sem: asyncio.Semaphore,
+    github_sem: asyncio.Semaphore,
+) -> dict:
+    blockscout = BlockscoutAPI_Async(
+        session=session,
+        api_keys=Config.BLOCKSCOUT_API_KEYS,
+        chain_config=Config.CHAIN_EXPLORER_CONFIG,
+    )
+    github = GitHubAPI_Async(
+        session=session,
+        headers=Config.get_github_headers(),
+        excluded_repos=Config.EXCLUDED_REPOS,
+    )
+    tenderly = TenderlyAPI_Async(session=session)
+    return await enrich_contract(contract, blockscout, github, tenderly, enrich_sem, github_sem)
+
+
+async def build_or_load(
+    address: str,
+    origin_key: str,
+    *,
+    dump_row: Optional[dict] = None,
+    refresh: bool = False,
+    session: Optional[aiohttp.ClientSession] = None,
+    enrich_sem: Optional[asyncio.Semaphore] = None,
+    github_sem: Optional[asyncio.Semaphore] = None,
+) -> dict:
+    """Return the classifier-input dict. Hits cache unless refresh=True."""
+    if not refresh:
+        cached = load_cached(address, origin_key)
+        if cached is not None:
+            return cached
+
+    # Cache miss — must run enrichment.
+    metrics = _fetch_db_metrics(address, origin_key) or (
+        _seed_metrics_from_dump_row(dump_row) if dump_row else {}
+    )
+    contract = {"address": address, "origin_key": origin_key, "metrics": metrics}
+
+    # chain_median_daa is required by classifier path G threshold.
+    inject_chain_median_daa([contract], days=7)
+
+    own_session = session is None
+    if own_session:
+        connector = aiohttp.TCPConnector(ssl=_ssl_ctx(), limit=10)
+        session = aiohttp.ClientSession(connector=connector)
+    if enrich_sem is None:
+        enrich_sem = asyncio.Semaphore(3)
+    if github_sem is None:
+        github_sem = asyncio.Semaphore(2)
+
+    try:
+        await _enrich_one(contract, session, enrich_sem, github_sem)
+    finally:
+        if own_session:
+            await session.close()
+
+    ctx = {
+        "metrics": contract.get("metrics", {}),
+        "blockscout": contract.get("blockscout", {}),
+        "github": contract.get("github", {"has_valid_repo": False}),
+        "traces": contract.get("traces", []),
+        "address_logs": contract.get("address_logs", []),
+        "token_transfers": contract.get("token_transfers", []),
+    }
+    save_cached(address, origin_key, ctx)
+    return ctx
+
+
+async def warm_many(rows: list[dict], refresh: bool = False, concurrency: int = 3) -> None:
+    """Bulk-build the cache for a list of dump rows.
+
+    Each row needs at minimum: address, origin_key (resolved slug). Skips rows already
+    cached unless refresh=True.
+    """
+    # Lazy chain config load (needs DB engine)
+    try:
+        from src.db_connector import DbConnector
+        _load_chain_config(DbConnector().engine)
+    except Exception as e:
+        logger.warning(f"chain config load skipped: {e}")
+
+    todo = [
+        r for r in rows
+        if r.get("address") and r.get("origin_key")
+        and (refresh or load_cached(r["address"], r["origin_key"]) is None)
+    ]
+    logger.info(f"warm: {len(todo)}/{len(rows)} rows need fetching (refresh={refresh})")
+    if not todo:
+        return
+
+    connector = aiohttp.TCPConnector(ssl=_ssl_ctx(), limit=20)
+    enrich_sem = asyncio.Semaphore(concurrency)
+    github_sem = asyncio.Semaphore(2)
+
+    async with aiohttp.ClientSession(connector=connector) as session:
+        async def _one(r):
+            try:
+                await build_or_load(
+                    r["address"], r["origin_key"],
+                    dump_row=r, refresh=refresh,
+                    session=session, enrich_sem=enrich_sem, github_sem=github_sem,
+                )
+                logger.info(f"cached {r['origin_key']}/{r['address']}")
+            except Exception as e:
+                logger.error(f"warm failed for {r.get('address')}: {e}")
+
+        await asyncio.gather(*(_one(r) for r in todo))
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    import argparse
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dump", default=str(_BACKEND_DIR / "local/validation_dump_2026-04-25/all_109_combined.json"))
+    ap.add_argument("--refresh", action="store_true")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--concurrency", type=int, default=3)
+    args = ap.parse_args()
+
+    rows = json.loads(Path(args.dump).read_text())
+    if args.limit:
+        rows = rows[: args.limit]
+    asyncio.run(warm_many(rows, refresh=args.refresh, concurrency=args.concurrency))

--- a/backend/labeling/eval/eval_human_corrections.py
+++ b/backend/labeling/eval/eval_human_corrections.py
@@ -1,0 +1,512 @@
+"""Classifier self-critique eval loop.
+
+Pipeline:
+  1. Load validation dump → filter to rows with human corrections.
+  2. For each row: build/load on-chain context (cache), re-run classify_contract.
+  3. Send (ai_rerun, ground_truth, raw_signals, current_system_prompt) to gemini-2.5-pro
+     using META_SYSTEM_INSTRUCTION → structured JSON critique + prompt-edit proposals.
+  4. Persist per_row.jsonl + aggregated report.md.
+
+CLI:
+  python -m backend.labeling.eval.eval_human_corrections \
+      --dump backend/local/validation_dump_2026-04-25/all_109_combined.json \
+      --run-id 2026-04-27_pass1 [--limit N] [--skip-meta] [--refresh]
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import re
+import ssl
+import sys
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import aiohttp
+from dotenv import load_dotenv
+
+# ── Path setup (mirror context_cache) ────────────────────────────────────────
+_THIS_DIR = Path(__file__).resolve().parent
+_LABELING_DIR = _THIS_DIR.parent
+_BACKEND_DIR = _LABELING_DIR.parent
+_REPO_ROOT = _BACKEND_DIR.parent
+for _p in [str(_LABELING_DIR), str(_BACKEND_DIR)]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+load_dotenv(dotenv_path=_BACKEND_DIR / ".env", override=False)
+load_dotenv(dotenv_path=_REPO_ROOT / ".env", override=False)
+load_dotenv(override=False)
+
+from ai_classifier import classify_contract, _SYSTEM_INSTRUCTION, _get_gemini_client  # noqa: E402
+from google.genai import types as genai_types  # noqa: E402
+
+# Sibling-module imports (this script can be run via `python eval_human_corrections.py`
+# from inside the eval/ dir, or `python -m` from anywhere). Add eval/ to sys.path.
+if str(_THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(_THIS_DIR))
+import context_cache as cc  # noqa: E402
+import re_eval_prompt as rep  # noqa: E402
+
+logger = logging.getLogger("eval.orchestrator")
+
+META_MODEL = "gemini-2.5-pro"
+
+RESULTS_DIR = _BACKEND_DIR / "local" / "eval_results"
+
+
+# ── Filtering ────────────────────────────────────────────────────────────────
+
+def load_rows_from_db() -> list[dict]:
+    """Load ground-truth rows by joining contract_label_review (humans) and contract_label_features (AI baseline).
+
+    Output schema matches the JSON-dump shape consumed by the rest of the orchestrator.
+    """
+    from src.db_connector import DbConnector
+    from sqlalchemy import text as sa_text
+    sql = sa_text("""
+        SELECT '0x' || encode(f.address, 'hex')           AS address,
+               f.origin_key                               AS origin_key,
+               f.ai_contract_name                         AS ai_contract_name,
+               f.ai_usage_category                        AS ai_usage_category,
+               f.ai_confidence                            AS confidence,
+               f.ai_reasoning                             AS _comment,
+               f.ai_owner_project_likely                  AS is_protocol_contract_likely,
+               f.ai_model                                 AS _source,
+               r.gtp_contract_name                        AS human_contract_name,
+               r.gtp_usage_category                       AS human_usage_category,
+               r.gtp_owner_project                        AS owner_project_linked,
+               (r.gtp_owner_project IS NOT NULL)          AS gtp_owner_project_confirmed,
+               COALESCE(r.gtp_no_owner_project, false)    AS gtp_no_owner_project,
+               ''::text                                   AS temp_owner_project,
+               ''::text                                   AS human_comment,
+               (r.id IS NOT NULL)                         AS approve
+        FROM public.contract_label_features f
+        LEFT JOIN LATERAL (
+            SELECT * FROM public.contract_label_review r2
+            WHERE r2.address = f.address AND r2.origin_key = f.origin_key
+            ORDER BY r2.reviewed_at DESC
+            LIMIT 1
+        ) r ON true
+        WHERE r.id IS NOT NULL
+          AND (r.name_was_changed
+               OR r.category_was_changed
+               OR r.owner_was_assigned
+               OR COALESCE(r.gtp_no_owner_project, false))
+    """)
+    db = DbConnector()
+    with db.engine.begin() as conn:
+        rows = [dict(m) for m in conn.execute(sql).mappings().all()]
+    logger.info(f"loaded {len(rows)} ground-truth rows from DB")
+    return rows
+
+
+def has_human_correction(row: dict) -> bool:
+    """A row counts as ground-truth iff a human supplied at least one signal."""
+    if (row.get("human_contract_name") or "").strip():
+        return True
+    if (row.get("human_usage_category") or "").strip():
+        return True
+    if row.get("gtp_owner_project_confirmed") and (row.get("owner_project_linked") or "").strip():
+        return True
+    if (row.get("temp_owner_project") or "").strip():
+        return True
+    if (row.get("human_comment") or "").strip():
+        return True
+    return False
+
+
+def ground_truth_block(row: dict) -> dict:
+    return {
+        "human_contract_name": row.get("human_contract_name") or "",
+        "human_usage_category": row.get("human_usage_category") or "",
+        "owner_project_linked": row.get("owner_project_linked") or "",
+        "gtp_owner_project_confirmed": bool(row.get("gtp_owner_project_confirmed")),
+        "gtp_no_owner_project": bool(row.get("gtp_no_owner_project")),
+        "temp_owner_project": row.get("temp_owner_project") or "",
+        "human_comment": row.get("human_comment") or "",
+        "approve": bool(row.get("approve")),
+    }
+
+
+def ai_original_block(row: dict) -> dict:
+    return {
+        "contract_name": row.get("ai_contract_name") or "",
+        "usage_category": row.get("ai_usage_category") or "",
+        "confidence": row.get("confidence"),
+        "reasoning": row.get("_comment") or "",
+        "is_protocol_contract_likely": bool(row.get("is_protocol_contract_likely")),
+        "_source": row.get("_source") or "",
+    }
+
+
+# ── Re-classify ──────────────────────────────────────────────────────────────
+
+async def reclassify_row(
+    row: dict,
+    session: aiohttp.ClientSession,
+    enrich_sem: asyncio.Semaphore,
+    github_sem: asyncio.Semaphore,
+    classify_sem: asyncio.Semaphore,
+    refresh: bool = False,
+) -> tuple[dict, dict]:
+    """Returns (ai_rerun, ctx). ai_rerun is the classifier's full return dict."""
+    address = row["address"]
+    origin_key = row["origin_key"]
+    ctx = await cc.build_or_load(
+        address, origin_key,
+        dump_row=row, refresh=refresh,
+        session=session, enrich_sem=enrich_sem, github_sem=github_sem,
+    )
+    async with classify_sem:
+        result = await classify_contract(
+            address=address,
+            origin_key=origin_key,
+            metrics=ctx.get("metrics", {}),
+            blockscout=ctx.get("blockscout", {}),
+            github=ctx.get("github", {}),
+            traces=ctx.get("traces", []),
+            session=session,
+            address_logs=ctx.get("address_logs", []),
+            token_transfers=ctx.get("token_transfers", []),
+        )
+    return result, ctx
+
+
+# ── Meta-eval ────────────────────────────────────────────────────────────────
+
+def _raw_signals_summary(ctx: dict) -> dict:
+    bs = ctx.get("blockscout", {}) or {}
+    gh = ctx.get("github", {}) or {}
+    metrics = ctx.get("metrics", {}) or {}
+    traces = ctx.get("traces", []) or []
+    logs = ctx.get("address_logs", []) or []
+    transfers = ctx.get("token_transfers", []) or []
+
+    named_in_traces = sorted({
+        c.get("contract", "") for t in traces for c in (t.get("protocol_calls") or [])
+        if c.get("contract")
+    })
+    transfer_summary = [
+        {"name": tt.get("token_name"), "symbol": tt.get("token_symbol")}
+        for tt in transfers[:10]
+    ]
+    return {
+        "blockscout": {
+            "contract_name": bs.get("contract_name"),
+            "is_verified": bs.get("is_verified"),
+            "is_proxy": bs.get("is_proxy"),
+            "impl_address": bs.get("impl_address"),
+        },
+        "github": {
+            "has_valid_repo": gh.get("has_valid_repo"),
+            "repo_url": gh.get("repo_url", ""),
+        },
+        "metrics": {
+            "txcount": metrics.get("txcount"),
+            "avg_daa": metrics.get("avg_daa"),
+            "success_rate": metrics.get("success_rate"),
+            "rel_cost": metrics.get("rel_cost"),
+            "day_range": metrics.get("day_range"),
+            "chain_median_daa": metrics.get("chain_median_daa"),
+        },
+        "traces_count": len(traces),
+        "address_logs_count": len(logs),
+        "token_transfers_count": len(transfers),
+        "named_contracts_in_traces_sample": named_in_traces[:20],
+        "token_transfers_sample": transfer_summary,
+    }
+
+
+def _meta_user_message(payload: dict) -> str:
+    """Pack everything the meta-evaluator needs into a single string user message."""
+    return (
+        "CURRENT_SYSTEM_PROMPT:\n"
+        "<<<\n" + _SYSTEM_INSTRUCTION + "\n>>>\n\n"
+        "GROUND_TRUTH:\n" + json.dumps(payload["ground_truth"], indent=2) + "\n\n"
+        "AI_RERUN:\n" + json.dumps(payload["ai_rerun"], indent=2, default=str) + "\n\n"
+        "AI_ORIGINAL:\n" + json.dumps(payload["ai_original"], indent=2, default=str) + "\n\n"
+        "RAW_SIGNALS:\n" + json.dumps(payload["raw_signals"], indent=2, default=str)
+    )
+
+
+async def meta_eval(payload: dict, sem: asyncio.Semaphore) -> dict:
+    client = _get_gemini_client()
+    user_msg = _meta_user_message(payload)
+
+    def _call():
+        return client.models.generate_content(
+            model=META_MODEL,
+            contents=user_msg,
+            config=genai_types.GenerateContentConfig(
+                system_instruction=rep.META_SYSTEM_INSTRUCTION,
+                response_mime_type="application/json",
+                response_schema=rep.META_RESPONSE_SCHEMA,
+                temperature=0.2,
+                max_output_tokens=4096,
+            ),
+        )
+
+    async with sem:
+        loop = asyncio.get_event_loop()
+        try:
+            response = await loop.run_in_executor(None, _call)
+        except Exception as e:
+            logger.error(f"meta_eval API call failed: {e}")
+            return {"errors": [], "prompt_edit_proposals": [], "severity": "low",
+                    "novel_pattern": False, "_meta_error": str(e)}
+
+    raw = response.text or ""
+    cleaned = re.sub(r",\s*([}\]])", r"\1", raw)
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        logger.warning(f"meta_eval JSON parse failed: {e} | raw: {raw[:200]!r}")
+        return {"errors": [], "prompt_edit_proposals": [], "severity": "low",
+                "novel_pattern": False, "_meta_error": "json_parse_failed",
+                "_meta_raw": raw[:1000]}
+
+
+# ── Aggregation ──────────────────────────────────────────────────────────────
+
+def aggregate(per_row_path: Path, out_md: Path, run_id: str) -> None:
+    rows = [json.loads(line) for line in per_row_path.read_text().splitlines() if line.strip()]
+    n = len(rows)
+
+    # Severity histogram
+    sev_counts = Counter(r.get("meta_eval", {}).get("severity", "low") for r in rows)
+    novel_rows = [r for r in rows if r.get("meta_eval", {}).get("novel_pattern")]
+    rows_with_errors = [r for r in rows if r.get("meta_eval", {}).get("errors")]
+
+    # Group errors by (category, root_cause_in_prompt)
+    error_buckets: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for r in rows:
+        for e in r.get("meta_eval", {}).get("errors", []):
+            key = (e.get("category", "?"), (e.get("root_cause_in_prompt") or "?")[:80])
+            error_buckets[key].append({
+                "address": r["address"],
+                "origin_key": r["origin_key"],
+                "what_went_wrong": e.get("what_went_wrong", ""),
+                "evidence": e.get("evidence_from_signals", ""),
+                "severity": r.get("meta_eval", {}).get("severity", "low"),
+            })
+
+    # Group prompt edits by target_section
+    edit_buckets: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        for p in r.get("meta_eval", {}).get("prompt_edit_proposals", []):
+            edit_buckets[(p.get("target_section") or "?")[:80]].append({
+                "address": r["address"],
+                "proposed_change": p.get("proposed_change", ""),
+                "rationale": p.get("rationale", ""),
+                "confidence": float(p.get("confidence", 0)),
+            })
+
+    sev_weight = {"low": 1, "medium": 2, "high": 3}
+
+    lines: list[str] = []
+    lines.append(f"# Classifier eval — run `{run_id}`")
+    lines.append("")
+    lines.append(f"- Rows evaluated: **{n}**")
+    lines.append(f"- Rows with at least one error: **{len(rows_with_errors)}** ({len(rows_with_errors) / n:.0%} of evaluated)" if n else "- Rows with at least one error: 0")
+    lines.append(f"- Severity: high={sev_counts.get('high',0)}  medium={sev_counts.get('medium',0)}  low={sev_counts.get('low',0)}")
+    lines.append(f"- Novel-pattern rows: **{len(novel_rows)}**")
+    lines.append("")
+
+    lines.append("## 1. Recurring error patterns")
+    lines.append("")
+    sorted_buckets = sorted(
+        error_buckets.items(),
+        key=lambda kv: (
+            -sum(sev_weight.get(x["severity"], 1) for x in kv[1]),
+            -len(kv[1]),
+        ),
+    )
+    if not sorted_buckets:
+        lines.append("_No errors recorded._")
+    for (cat, root), items in sorted_buckets:
+        weight = sum(sev_weight.get(x["severity"], 1) for x in items)
+        lines.append(f"### {cat} — {root}")
+        lines.append(f"- count={len(items)}  severity_weight={weight}")
+        for ex in items[:3]:
+            lines.append(f"  - `{ex['origin_key']}/{ex['address']}` — {ex['what_went_wrong']}")
+            if ex["evidence"]:
+                lines.append(f"    - evidence: {ex['evidence']}")
+        lines.append("")
+
+    lines.append("## 2. Ranked prompt-edit proposals")
+    lines.append("")
+    sorted_edits = sorted(
+        edit_buckets.items(),
+        key=lambda kv: -(len(kv[1]) * (sum(x["confidence"] for x in kv[1]) / max(len(kv[1]), 1))),
+    )
+    if not sorted_edits:
+        lines.append("_No proposals._")
+    for section, props in sorted_edits:
+        avg_conf = sum(p["confidence"] for p in props) / max(len(props), 1)
+        lines.append(f"### `{section}`  (proposals: {len(props)}, avg_conf: {avg_conf:.2f})")
+        # Show top-3 distinct proposed_change strings by confidence
+        seen: set[str] = set()
+        for p in sorted(props, key=lambda x: -x["confidence"]):
+            key = p["proposed_change"][:120]
+            if key in seen:
+                continue
+            seen.add(key)
+            lines.append(f"- **conf={p['confidence']:.2f}** — {p['proposed_change']}")
+            if p["rationale"]:
+                lines.append(f"  - rationale: {p['rationale']}")
+            if len(seen) >= 3:
+                break
+        lines.append("")
+
+    lines.append("## 3. Novel patterns (not P1–P7)")
+    lines.append("")
+    if not novel_rows:
+        lines.append("_None._")
+    for r in novel_rows[:20]:
+        gt = r.get("ground_truth", {})
+        ai = r.get("ai_rerun", {})
+        lines.append(
+            f"- `{r['origin_key']}/{r['address']}` — ai_name={ai.get('contract_name')!r} "
+            f"ai_cat={ai.get('usage_category')!r} | human_name={gt.get('human_contract_name')!r} "
+            f"human_cat={gt.get('human_usage_category')!r}"
+        )
+        for e in r.get("meta_eval", {}).get("errors", [])[:2]:
+            lines.append(f"  - {e.get('category')}: {e.get('what_went_wrong')}")
+    lines.append("")
+
+    lines.append("## 4. Per-row diff (AI original vs rerun vs human)")
+    lines.append("")
+    lines.append("| origin/addr | ai_orig name | ai_rerun name | human name | ai_orig cat | ai_rerun cat | human cat | severity |")
+    lines.append("|---|---|---|---|---|---|---|---|")
+    for r in rows:
+        ao = r.get("ai_original", {})
+        ar = r.get("ai_rerun", {})
+        gt = r.get("ground_truth", {})
+        sev = r.get("meta_eval", {}).get("severity", "low")
+        lines.append(
+            f"| `{r['origin_key']}/{r['address'][:10]}…` "
+            f"| {ao.get('contract_name','')} | {ar.get('contract_name','')} | {gt.get('human_contract_name','')} "
+            f"| {ao.get('usage_category','')} | {ar.get('usage_category','')} | {gt.get('human_usage_category','')} "
+            f"| {sev} |"
+        )
+
+    out_md.write_text("\n".join(lines) + "\n")
+    logger.info(f"wrote aggregated report → {out_md}")
+
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+
+async def run(
+    dump_path: Path,
+    run_id: str,
+    limit: int = 0,
+    skip_meta: bool = False,
+    refresh: bool = False,
+    classify_concurrency: int = 3,
+    meta_concurrency: int = 3,
+    source: str = 'json',
+) -> None:
+    if source == 'db':
+        rows = load_rows_from_db()
+    else:
+        rows = json.loads(dump_path.read_text())
+    filtered = [r for r in rows if r.get("address") and r.get("origin_key") and has_human_correction(r)]
+    if limit:
+        filtered = filtered[:limit]
+    logger.info(f"{len(filtered)}/{len(rows)} rows have human corrections (limit={limit or 'none'})")
+
+    out_dir = RESULTS_DIR / run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    per_row_path = out_dir / "per_row.jsonl"
+    report_path = out_dir / "report.md"
+
+    # Lazy chain config (DB)
+    try:
+        from src.db_connector import DbConnector
+        from automated_labeler import _load_chain_config
+        _load_chain_config(DbConnector().engine)
+    except Exception as e:
+        logger.warning(f"chain config load skipped: {e}")
+
+    connector = aiohttp.TCPConnector(ssl=cc._ssl_ctx(), limit=20)
+    enrich_sem = asyncio.Semaphore(3)
+    github_sem = asyncio.Semaphore(2)
+    classify_sem = asyncio.Semaphore(classify_concurrency)
+    meta_sem = asyncio.Semaphore(meta_concurrency)
+
+    written = 0
+    with per_row_path.open("w") as out_f:
+        async with aiohttp.ClientSession(connector=connector) as session:
+
+            async def _process(row: dict) -> Optional[dict]:
+                try:
+                    ai_rerun, ctx = await reclassify_row(
+                        row, session, enrich_sem, github_sem, classify_sem, refresh=refresh
+                    )
+                except Exception as e:
+                    logger.error(f"reclassify failed for {row.get('address')}: {e}")
+                    return None
+
+                payload = {
+                    "address": row["address"],
+                    "origin_key": row["origin_key"],
+                    "ground_truth": ground_truth_block(row),
+                    "ai_original": ai_original_block(row),
+                    "ai_rerun": ai_rerun,
+                    "raw_signals": _raw_signals_summary(ctx),
+                }
+                if not skip_meta:
+                    payload["meta_eval"] = await meta_eval(payload, meta_sem)
+                else:
+                    payload["meta_eval"] = {
+                        "errors": [], "prompt_edit_proposals": [],
+                        "severity": "low", "novel_pattern": False, "_skipped": True,
+                    }
+                payload["ts"] = datetime.now(timezone.utc).isoformat()
+                return payload
+
+            results = await asyncio.gather(*(_process(r) for r in filtered))
+            for res in results:
+                if res is None:
+                    continue
+                out_f.write(json.dumps(res, default=str) + "\n")
+                written += 1
+
+    logger.info(f"wrote {written} rows → {per_row_path}")
+    aggregate(per_row_path, report_path, run_id)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--source", choices=["json", "db"], default="json",
+                    help="json=read from --dump file; db=join contract_label_features + contract_label_review")
+    ap.add_argument("--dump", default=str(_BACKEND_DIR / "local/validation_dump_2026-04-25/all_109_combined.json"))
+    ap.add_argument("--run-id", default=time.strftime("%Y-%m-%d_%H%M%S"))
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--skip-meta", action="store_true")
+    ap.add_argument("--refresh", action="store_true")
+    ap.add_argument("--classify-concurrency", type=int, default=3)
+    ap.add_argument("--meta-concurrency", type=int, default=3)
+    args = ap.parse_args()
+
+    asyncio.run(run(
+        dump_path=Path(args.dump),
+        run_id=args.run_id,
+        limit=args.limit,
+        skip_meta=args.skip_meta,
+        refresh=args.refresh,
+        classify_concurrency=args.classify_concurrency,
+        meta_concurrency=args.meta_concurrency,
+        source=args.source,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/labeling/eval/re_eval_prompt.py
+++ b/backend/labeling/eval/re_eval_prompt.py
@@ -1,0 +1,117 @@
+"""Meta-evaluator prompt for self-critique of the contract classifier.
+
+The eval orchestrator passes (ai_output, ground_truth, raw_signals, current_system_prompt)
+to a stronger model (gemini-2.5-pro) instructed by META_SYSTEM_INSTRUCTION below.
+
+Output JSON schema is enforced via Gemini's response_schema. See
+META_RESPONSE_SCHEMA at the bottom of this file.
+"""
+
+META_SYSTEM_INSTRUCTION = """You are a senior reviewer auditing a smart-contract classification model against human-verified ground truth.
+
+You receive five blocks for a single contract:
+
+  1. CURRENT_SYSTEM_PROMPT — the prompt the classifier (Gemini 2.5 Flash) is using right now.
+     It defines decision PATHs A, B, C, D, E, F, G1, G2, G3, O and a name-derivation section.
+
+  2. GROUND_TRUTH — human-verified labels. Any of these fields may be empty (no human change):
+       human_contract_name           : corrected name string
+       human_usage_category          : corrected category slug
+       owner_project_linked          : confirmed OSS project slug (only valid when gtp_owner_project_confirmed=true)
+       gtp_owner_project_confirmed   : bool — human confirmed an OSS project owner
+       gtp_no_owner_project          : bool — human confirmed there is NO owner (model should NOT have asserted protocol_likely)
+       temp_owner_project            : free-text novel-protocol name the model failed to recognise
+       human_comment                 : free-text reviewer note (often the most direct evidence)
+
+  3. AI_RERUN — current model output: {contract_name, usage_category, confidence, reasoning, novel_tokens?}
+
+  4. AI_ORIGINAL — the prior production output (may match AI_RERUN; if it differs, the model has drifted).
+
+  5. RAW_SIGNALS — what the classifier actually saw:
+       blockscout : {contract_name, is_verified, is_proxy, impl_address}
+       github     : {has_valid_repo, repo_url}
+       metrics    : {txcount, avg_daa, success_rate, rel_cost, day_range, chain_median_daa}
+       traces     : count + sample of named contracts called
+       address_logs : decoded log signal counts
+       token_transfers : token names/symbols moved through this contract
+
+Your job for each contract:
+
+  A) Identify every concrete error vs ground truth. One error object per dimension that diverges
+     (name, category, owner, protocol_likely, reasoning_quality).
+     - 'reasoning_quality' = the chain-of-thought in AI_RERUN.reasoning is logically wrong even if
+       the final label happens to match.
+     - For each error: cite which signal in RAW_SIGNALS *should* have steered the model right,
+       AND which section / PATH in CURRENT_SYSTEM_PROMPT misled it.
+
+  B) Propose specific, surgical edits to CURRENT_SYSTEM_PROMPT. Each proposal must name the target
+     section verbatim (e.g. "PATH G2", "name-derivation", "PATH O", "sentinel rule for novel_tokens")
+     and provide ≤3 sentences of replacement / additional text that the engineer can paste in.
+     Avoid vague advice. If your edit changes a numeric threshold, justify it from the signals.
+
+  C) Severity:
+       low    — minor naming nit, category off-by-one between adjacent buckets
+       medium — wrong category in a way that misleads category aggregations OR misses a real owner
+       high   — wrong on protocol_likely (false positive or false negative), wrong asset class
+                 (e.g. labelled trading when the contract is clearly a bridge), OR labelled with
+                 high confidence (>0.7) something a human flagged as wrong.
+
+  D) novel_pattern: true ONLY if this row's error class is NOT covered by these known patterns:
+       P1 — generic "Ambiguous Contract" name when traces have signal
+       P2 — Blockscout token transfers overriding trace-derived naming
+       P3 — DEXAggregator misused for low-DAA MEV/arbitrage bots
+       P4 — novel-protocol tokens not flagged as protocol_likely
+       P5 — PATH F (price-scanner) false positive on single-pool slot0 reads
+       P6 — PATH O (oracle) false positive on incidental getter calls
+       P7 — PATH E clones named StrategyExecutor instead of CloneExecutor
+     Otherwise false.
+
+Hard rules:
+  - Output STRICT JSON, no markdown, no commentary.
+  - If GROUND_TRUTH carries no human edits at all, return errors=[], severity="low", novel_pattern=false.
+    A row with approve=true and no edits is the model getting it right; do not invent errors.
+  - Quote signal evidence concisely: "matched_dex_pools=3 across distinct pools" not paragraphs.
+  - prompt_edit_proposals[].confidence is YOUR confidence the edit will help — calibrate honestly."""
+
+
+# Gemini structured-output schema. Mirrors the JSON shape the meta prompt instructs.
+META_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "errors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "category": {
+                        "type": "string",
+                        "enum": ["name", "category", "owner", "protocol_likely", "reasoning_quality"],
+                    },
+                    "what_went_wrong": {"type": "string"},
+                    "root_cause_in_prompt": {"type": "string"},
+                    "evidence_from_signals": {"type": "string"},
+                },
+                "required": ["category", "what_went_wrong", "root_cause_in_prompt", "evidence_from_signals"],
+                "propertyOrdering": ["category", "what_went_wrong", "root_cause_in_prompt", "evidence_from_signals"],
+            },
+        },
+        "prompt_edit_proposals": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "target_section": {"type": "string"},
+                    "proposed_change": {"type": "string"},
+                    "rationale": {"type": "string"},
+                    "confidence": {"type": "number"},
+                },
+                "required": ["target_section", "proposed_change", "rationale", "confidence"],
+                "propertyOrdering": ["target_section", "proposed_change", "rationale", "confidence"],
+            },
+        },
+        "severity": {"type": "string", "enum": ["low", "medium", "high"]},
+        "novel_pattern": {"type": "boolean"},
+    },
+    "required": ["errors", "prompt_edit_proposals", "severity", "novel_pattern"],
+    "propertyOrdering": ["errors", "prompt_edit_proposals", "severity", "novel_pattern"],
+}

--- a/backend/src/db_connector.py
+++ b/backend/src/db_connector.py
@@ -2157,7 +2157,34 @@ class DbConnector:
 
                 df = pd.read_sql(exec_string, self.engine.connect())
                 return df
-        
+
+        # TODO(contract_label_features): add three new methods here for the approval workflow.
+        #
+        # 1. upsert_contract_label_features(rows: list[dict])
+        #    Bulk upsert into public.contract_label_features (ON CONFLICT (address, origin_key) DO UPDATE).
+        #    Array columns (novel_tokens, matched_routers, etc.) → PostgreSQL text[].
+        #    jsonb columns (bs_token_transfers, log_top_events) → json.dumps().
+        #    address → decode(addr_hex, 'hex').
+        #    Called by automated_labeler.py after classification, before OLI attestation.
+        #
+        # 2. insert_contract_label_review(rows: list[dict])
+        #    Append-only INSERT into public.contract_label_review (no ON CONFLICT — audit log).
+        #    Captures the diff between AI output (from contract_label_features) and GTP-attested values.
+        #    Called by oli_airtable.py in airtable_read_automated_labels() and
+        #    airtable_read_label_pool_reattest() immediately before oli.submit_label().
+        #    Columns: address, origin_key, labeled_at, reviewed_at, review_source,
+        #             ai_contract_name, ai_usage_category, ai_confidence, ai_owner_project_likely,
+        #             gtp_contract_name, gtp_usage_category, gtp_owner_project, gtp_no_owner_project,
+        #             name_was_changed, category_was_changed, owner_was_assigned.
+        #
+        # 3. get_contract_label_features(address_origin_pairs: list[tuple[str, str]]) -> dict
+        #    SELECT ai_contract_name, ai_usage_category, ai_confidence, ai_owner_project_likely, labeled_at
+        #    FROM public.contract_label_features
+        #    WHERE (address, origin_key) IN (...)
+        #    Returns dict keyed by (address, origin_key) for O(1) lookup in oli_airtable.py.
+        #
+        # DDL for both tables is in docs/contract_label_features_schema.md.
+
         ## TODO: filter by contracts only?
         def get_labels_lite_db(self, limit=50000, order_by='txcount', origin_keys=None):
                 exec_string = f"""

--- a/backend/src/db_connector.py
+++ b/backend/src/db_connector.py
@@ -2158,32 +2158,71 @@ class DbConnector:
                 df = pd.read_sql(exec_string, self.engine.connect())
                 return df
 
-        # TODO(contract_label_features): add three new methods here for the approval workflow.
-        #
-        # 1. upsert_contract_label_features(rows: list[dict])
-        #    Bulk upsert into public.contract_label_features (ON CONFLICT (address, origin_key) DO UPDATE).
-        #    Array columns (novel_tokens, matched_routers, etc.) → PostgreSQL text[].
-        #    jsonb columns (bs_token_transfers, log_top_events) → json.dumps().
-        #    address → decode(addr_hex, 'hex').
-        #    Called by automated_labeler.py after classification, before OLI attestation.
-        #
-        # 2. insert_contract_label_review(rows: list[dict])
-        #    Append-only INSERT into public.contract_label_review (no ON CONFLICT — audit log).
-        #    Captures the diff between AI output (from contract_label_features) and GTP-attested values.
-        #    Called by oli_airtable.py in airtable_read_automated_labels() and
-        #    airtable_read_label_pool_reattest() immediately before oli.submit_label().
-        #    Columns: address, origin_key, labeled_at, reviewed_at, review_source,
-        #             ai_contract_name, ai_usage_category, ai_confidence, ai_owner_project_likely,
-        #             gtp_contract_name, gtp_usage_category, gtp_owner_project, gtp_no_owner_project,
-        #             name_was_changed, category_was_changed, owner_was_assigned.
-        #
-        # 3. get_contract_label_features(address_origin_pairs: list[tuple[str, str]]) -> dict
-        #    SELECT ai_contract_name, ai_usage_category, ai_confidence, ai_owner_project_likely, labeled_at
-        #    FROM public.contract_label_features
-        #    WHERE (address, origin_key) IN (...)
-        #    Returns dict keyed by (address, origin_key) for O(1) lookup in oli_airtable.py.
-        #
-        # DDL for both tables is in docs/contract_label_features_schema.md.
+        # ── contract_label_features / contract_label_review ──────────────────
+        # Schema: docs/contract_label_features_schema.md
+        # DDL:    backend/db_migrations/001_contract_label_features.sql
+
+        def upsert_contract_label_features(self, rows: list[dict]) -> int:
+                """Bulk-upsert AI feature rows. Idempotent on (address, origin_key)."""
+                if not rows:
+                        return 0
+                df = pd.DataFrame(rows)
+                # Address → bytea via the same \\x-prefix convention used elsewhere.
+                df['address'] = df['address'].astype(str).str.lower().str.replace('0x', '\\x', regex=False)
+                # jsonb cols: pangres serialises dict/list automatically; coerce None safely.
+                for jcol in ('bs_token_transfers', 'log_top_events'):
+                        if jcol in df.columns:
+                                df[jcol] = df[jcol].apply(lambda v: v if v is not None else None)
+                # Set composite PK so pangres knows what to ON CONFLICT against.
+                df = df.set_index(['address', 'origin_key'])
+                return self.upsert_table('public.contract_label_features', df, if_exists='update') or 0
+
+        def insert_contract_label_review(self, rows: list[dict]) -> int:
+                """Append-only insert. Generated diff-flag columns auto-populate."""
+                if not rows:
+                        return 0
+                insert_sql = text("""
+                    INSERT INTO public.contract_label_review (
+                        address, origin_key, labeled_at, reviewed_at, review_source,
+                        ai_contract_name, ai_usage_category, ai_confidence, ai_owner_project_likely,
+                        gtp_contract_name, gtp_usage_category, gtp_owner_project, gtp_no_owner_project
+                    ) VALUES (
+                        :address, :origin_key, :labeled_at, :reviewed_at, :review_source,
+                        :ai_contract_name, :ai_usage_category, :ai_confidence, :ai_owner_project_likely,
+                        :gtp_contract_name, :gtp_usage_category, :gtp_owner_project, :gtp_no_owner_project
+                    )
+                """)
+                normalised = []
+                for r in rows:
+                        n = dict(r)
+                        if isinstance(n.get('address'), str) and n['address'].startswith('0x'):
+                                n['address'] = n['address'].lower().replace('0x', '\\x')
+                        normalised.append(n)
+                with self.engine.begin() as conn:
+                        conn.execute(insert_sql, normalised)
+                return len(normalised)
+
+        def get_contract_label_features(self, address_origin_pairs: list[tuple]) -> dict:
+                """Lookup AI baseline for diff capture. Returns dict[(address_0x, origin_key)] -> row."""
+                if not address_origin_pairs:
+                        return {}
+                # Normalise lookup keys (always 0x-lower hex).
+                pairs = [(a.lower() if a.startswith('0x') else '0x' + a.lower().lstrip('\\x'), ok)
+                         for a, ok in address_origin_pairs]
+                hex_addrs = [a[2:] for a, _ in pairs]
+                origin_keys = [ok for _, ok in pairs]
+                sql = text("""
+                    SELECT '0x' || encode(address, 'hex') AS address, origin_key,
+                           labeled_at, ai_contract_name, ai_usage_category, ai_confidence,
+                           ai_owner_project_likely
+                    FROM public.contract_label_features
+                    WHERE (encode(address, 'hex'), origin_key) = ANY(
+                        SELECT unnest(CAST(:addrs AS text[])), unnest(CAST(:oks AS text[]))
+                    )
+                """)
+                with self.engine.begin() as conn:
+                        rows = conn.execute(sql, {'addrs': hex_addrs, 'oks': origin_keys}).mappings().all()
+                return {(r['address'], r['origin_key']): dict(r) for r in rows}
 
         ## TODO: filter by contracts only?
         def get_labels_lite_db(self, limit=50000, order_by='txcount', origin_keys=None):

--- a/backend/src/misc/airtable_functions.py
+++ b/backend/src/misc/airtable_functions.py
@@ -220,7 +220,7 @@ def read_all_label_pool_reattest(api, AIRTABLE_BASE_ID, table, approved=True):
     if df.empty:
         print('no contracts marked for reattesting.')
         return
-    
+
     if 'approve' not in df.columns and approved:
         print('no contracts marked for reattesting with approve column set to true.')
         return
@@ -236,7 +236,7 @@ def read_all_label_pool_reattest(api, AIRTABLE_BASE_ID, table, approved=True):
     # only keep rows where approve is set to true
     if approved:
         df = df[df['approve'] == True]
-    
+
     # drop not needded columns
     df = df[['address', 'origin_key', 'contract_name', 'owner_project', 'usage_category', 'attester', 'id']]
 
@@ -266,5 +266,110 @@ def read_all_label_pool_reattest(api, AIRTABLE_BASE_ID, table, approved=True):
     # convert address to bytes
     df['address'] = df['address'].str.replace('0x', '\\x', regex=False)
     df['attester'] = df['attester'].str.replace('0x', '\\x', regex=False)
+
+    return df
+
+
+# Read approved rows from "Label Pool Automated" with human-override coalesce + AI snapshot.
+# Kept SEPARATE from read_all_label_pool_reattest to keep concerns isolated:
+#   - reattest reader: classic single-table flow used by external attesters' submissions.
+#   - automated reader: this function, used only by airtable_read_automated_labels — applies
+#     the human-edit override (contract_name_human, new_usage_category) and exposes
+#     temp_owner_project + gtp_no_owner_project so the call site can write contract_label_review.
+def read_all_label_pool_automated(api, AIRTABLE_BASE_ID, table, approved=True):
+    """Read approved rows from "Label Pool Automated".
+
+    Behaviour distinct from read_all_label_pool_reattest:
+      - Coalesces human edits over AI fields:
+            contract_name  ← contract_name_human  if human set it
+            usage_category ← new_usage_category   if human set it
+      - Owner-project resolution:
+            linked `owner_project` recID → OSS slug — ATTESTED.
+            `temp_owner_project` (free text)        — preserved as separate column,
+                                                       review-only, NEVER attested on-chain.
+            `gtp_no_owner_project=True`             — drops `owner_project` from attestation.
+            Placeholder slug 'protocol-contract-likely' is dropped.
+      - Snapshots AI values BEFORE coalesce so the diff capture downstream sees both sides.
+      - Returns columns: address, chain_id, contract_name, owner_project, usage_category,
+        ai_contract_name, ai_usage_category, temp_owner_project, gtp_no_owner_project,
+        attester, id.
+    """
+    df = read_airtable(table)
+    if df.empty:
+        print('no contracts in Label Pool Automated.')
+        return
+    if 'approve' not in df.columns and approved:
+        print('no approved automated contracts.')
+        return
+
+    for col, default in [
+        ('contract_name', ''), ('owner_project', None), ('usage_category', None),
+        ('contract_name_human', ''), ('new_usage_category', None),
+        ('temp_owner_project', ''), ('gtp_no_owner_project', False),
+        ('attester', None),
+    ]:
+        if col not in df.columns:
+            df[col] = default
+
+    if approved:
+        df = df[df['approve'] == True]
+    if df.empty:
+        return df
+
+    # Snapshot AI baseline BEFORE coalesce — feeds the contract_label_review diff.
+    df['ai_contract_name'] = df['contract_name']
+    df['ai_usage_category'] = df['usage_category']
+
+    def _nonempty(v):
+        if isinstance(v, str):
+            return v.strip() != ''
+        if isinstance(v, list):
+            return len(v) > 0
+        return v is not None and not pd.isna(v)
+
+    df['contract_name'] = df.apply(
+        lambda r: r['contract_name_human'] if _nonempty(r.get('contract_name_human')) else r['contract_name'],
+        axis=1,
+    )
+    df['usage_category'] = df.apply(
+        lambda r: r['new_usage_category'] if _nonempty(r.get('new_usage_category')) else r['usage_category'],
+        axis=1,
+    )
+
+    keep = ['address', 'origin_key', 'contract_name', 'owner_project', 'usage_category',
+            'ai_contract_name', 'ai_usage_category', 'temp_owner_project',
+            'gtp_no_owner_project', 'attester', 'id']
+    df = df[[c for c in keep if c in df.columns]]
+
+    # Linked records arrive as 1-element lists; pull the recID.
+    for c in ['owner_project', 'usage_category', 'origin_key', 'ai_usage_category']:
+        if c in df.columns:
+            df[c] = df[c].apply(lambda x: x[0] if isinstance(x, list) and x else x)
+
+    # Resolve recIDs → slugs.
+    if df['owner_project'].notna().any():
+        df_owner_projects = read_airtable(api.table(AIRTABLE_BASE_ID, 'OSS Projects'))[['id', 'Name']].set_index('id')
+        df['owner_project'] = df['owner_project'].apply(
+            lambda x: df_owner_projects.loc[x]['Name'] if isinstance(x, str) and x.startswith('rec') and x in df_owner_projects.index else x)
+    if df['usage_category'].notna().any() or df['ai_usage_category'].notna().any():
+        df_cats = read_airtable(api.table(AIRTABLE_BASE_ID, 'Sub Categories'))[['id', 'category_id']].set_index('id')
+        for c in ['usage_category', 'ai_usage_category']:
+            df[c] = df[c].apply(
+                lambda x: df_cats.loc[x]['category_id'] if isinstance(x, str) and x.startswith('rec') and x in df_cats.index else x)
+    if df['origin_key'].notna().any():
+        df_chains = read_airtable(api.table(AIRTABLE_BASE_ID, 'Chains'))[['id', 'caip2']].set_index('id')
+        df['chain_id'] = df['origin_key'].apply(
+            lambda x: df_chains.loc[x]['caip2'] if isinstance(x, str) and x.startswith('rec') and x in df_chains.index else None)
+        df = df.drop(columns=['origin_key'])
+
+    # gtp_no_owner_project / placeholder-sentinel: drop owner_project when not attestable.
+    df['gtp_no_owner_project'] = df['gtp_no_owner_project'].fillna(False).astype(bool)
+    df.loc[df['gtp_no_owner_project'] | (df['owner_project'] == 'protocol-contract-likely'), 'owner_project'] = None
+    df['temp_owner_project'] = df['temp_owner_project'].apply(
+        lambda v: v.strip() if isinstance(v, str) and v.strip() else None)
+
+    df['address'] = df['address'].apply(lambda x: x.replace('0x', '\\x') if isinstance(x, str) else x)
+    if df['attester'].notna().any():
+        df['attester'] = df['attester'].apply(lambda x: x.replace('0x', '\\x') if isinstance(x, str) else x)
 
     return df

--- a/docs/classifier_prompt_improvements_2026-04-28.md
+++ b/docs/classifier_prompt_improvements_2026-04-28.md
@@ -1,0 +1,135 @@
+# Classifier Prompt + Logic Improvements — 2026-04-28
+
+Author: rolling notes
+Scope: `backend/labeling/ai_classifier.py` (system prompt + response schema), `backend/labeling/automated_labeler.py` (sentinel), `backend/labeling/eval/` (self-critique loop).
+
+## Why
+
+After 109 human-validated rows from the 2026-04-24 labeling round + the 2026-04-27 batch, the classifier showed three persistent failure modes that human review kept catching:
+
+1. The model would correctly reason `→ trading` / `→ oracle` / `→ bridge` but emit `usage_category: "other"`. **80 / 127 rows in the baseline.**
+2. Generic `AmbiguousContract` names appeared even when traces had clear protocol identity, because Blockscout token-transfer names dominated naming for simple proxies.
+3. Verified or github-linked protocol contracts were misclassified as private trading bots in PATH G1, because the EXCEPTION clause was buried inside the path.
+
+A self-critique eval loop (`backend/labeling/eval/`) was built to drive this iteratively: re-classify rows that have human corrections, ask `gemini-2.5-pro` to diagnose what went wrong against the current system prompt, and aggregate the proposed prompt edits across runs. Three iteration rounds (v1 baseline → v2 → v3) followed.
+
+## Quantified outcome
+
+| metric | v1 baseline | v2 (schema) | v3 (prompt) | Δ vs v1 |
+|---|---|---|---|---|
+| Rows with errors (of 127) | 106 | 108 | 102 | -4 |
+| Reasoning↔output contradictions | **80** | 0 | 0 | **-80** |
+| `usage_category="other"` (hedging) | 127 | 5 | 7 | -120 |
+| **High-severity errors** | **79** | 41 | **26** | **-67%** |
+| Medium severity | 27 | 52 | 56 | +29 |
+| Low severity | 21 | 34 | 45 | +24 |
+| Meta-eval failures | 20 | 6 | 10 | -10 |
+
+Severity distribution shifted decisively toward less-severe errors: high cut by two-thirds, with the residual moving into medium and low buckets where the model is wrong but not catastrophically.
+
+## Round-by-round changes
+
+### Round 1 (v2) — Response schema fix (the single biggest win)
+
+**Root cause.** The Gemini structured-output schema declared `properties` in the order `contract_name`, `usage_category`, `confidence`, `reasoning` with `required=["contract_name", "usage_category"]`. With no `property_ordering`, Flash generated `usage_category` BEFORE `reasoning` — committing to a category before deriving the path conclusion. The safe hedge was `"other"`. The reasoning text, generated afterward, would then conclude `→ trading` (etc.), producing the 80/127 contradictions.
+
+Additionally, `usage_category` had no `enum` constraint. The post-process at the bottom of `classify_contract()` rewrites unknown categories to `fallback_id` (`"other"`), compounding the problem when Flash hallucinated category strings.
+
+**Fix.** `backend/labeling/ai_classifier.py:925-955`:
+- `enum=valid_ids` on `usage_category` (constrains to OLI valid IDs, eliminates fallback rewrites).
+- `property_ordering=["reasoning", "contract_name", "usage_category", "confidence"]` (forces reasoning first).
+- `required=["reasoning", "contract_name", "usage_category"]` (reasoning is no longer optional).
+
+**Result.** 80 contradictions → 0. `"other"` hedging dropped from 127 / 127 to 5 / 127. High-severity errors dropped from 79 to 41.
+
+### Round 1 (v2) — First batch of prompt edits
+
+Driven by the v1 eval's ranked proposals (PATH A had 17 distinct proposals at avg conf 0.91):
+
+- **HOW TO CLASSIFY**: added GitHub repository as a third primary source of truth alongside verified name and trace behavior; added an "Output discipline" rule that `reasoning` must end with `→ <category>` matching `usage_category`.
+- **PATH A — protocol-specific corrections**: added `Socket* → bridge`, `*OffchainAggregator / AccessControlledOffchainAggregator → oracle` (Chainlink), `OpenOceanSwapModule → nft_marketplace`, `ConditionalTokens / CTFExchange / NegRiskAdapter → prediction_markets` (Polymarket pattern), `IdRegistry / *Registrar → identity` (Farcaster, ENS).
+- **PATH O — Oracle Infrastructure**: added `transmit`, `fulfillOracleRequest`, `fulfillOracleRequest2`, `postPrices` to the oracle function list (Chainlink Operator pattern). Made oracle classification "sticky" — once determined, do not fall back. Added a soft-exception so a single incidental getter call doesn't outweigh dominant non-oracle activity.
+- **PATH G3 — Public Callers**: added the low-success-rate override (`success_rate < 60%` + DEX traces → `trading` MEVBot/ArbitrageBot, even with PUBLIC callers — many callers competing and failing is the MEV signature).
+- **name-derivation**: explicit priority order (verified name > traces > novel_tokens > behavioral). Forbid naming a contract after a `bs_token_transfers` token when `named_contracts_in_traces` is non-empty.
+
+### Round 2 (v3) — Round-2 prompt edits + the avg_daa discriminator
+
+The v2 report surfaced new top patterns once the contradiction class was eliminated. Key additions:
+
+- **PATH O**: added `updatePrices` (Stork-pattern price pushers were being missed).
+- **PATH A**: added `*Factory / *Deployer / *Creator → developer_tools` (factories should be classified by their role as deployment infra, not by what they deploy). Added `TransparentUpgradeableProxy / ERC1967Proxy → developer_tools` for cases where the generic proxy name does reach the classifier.
+- **PATH G1 EXCEPTION**: extended `verified contracts` to `verified contracts OR github.has_valid_repo=true`. Added an exception-to-the-exception: verified or github-linked contracts whose dominant activity is automated LP management (CLPool/CLGauge/NonfungiblePositionManager mint/burn/collect) ARE `trading`, even with confirmed identity. Symmetric edit applied to PATH G2.
+- **PATH G3**: stablecoin name-pattern as primary signal (`USD/Stable/USDC/USDT/USDM/BUSD/TUSD/FRAX/LUSD` → `stablecoin`); airdrop pattern recognition (`Claim/Airdrop/Distributor/Vesting/Rewards/Points` with broad user base → `airdrop`); explicit avg_daa gate referenced.
+
+#### avg_daa Discriminator (new dedicated section)
+
+Reviewer feedback: the strongest discriminator between a private trading bot and public DEX infrastructure is **absolute avg_daa relative to chain_median_daa**, but the prompt was treating `avg_daa` as a tiebreaker. Added a dedicated section with three explicit tiers:
+
+  - **HIGH** (`avg_daa ≥ chain_median_daa AND avg_daa ≥ 50`): public infrastructure by definition — many independent users. Cannot be a private trading bot regardless of how trading-shaped the traces look. Even bot-shaped DEX activity is overridden to `dex` / `bridge` / `oracle` / etc. by trace content.
+  - **LOW** (`avg_daa < max(chain_median_daa × 0.05, 3)`): private operator(s). The `DEXAggregator` label is invalid at this DAA level unless callers can be confirmed as real public EOAs (not admin/keeper EOAs cycling addresses). LOW + `success_rate < 90%` + DEX activity → `trading` (MEVBot/ArbitrageBot). LOW + `success_rate ≥ 90%` + DEX activity → `trading` (StrategyExecutor / [Protocol]Rebalancer).
+  - **MID**: examine caller diversity and success rate; default to `trading` when in doubt. `DEXAggregator` is a strong claim that requires strong evidence.
+
+Hard rule: when picking the name `DEXAggregator`, the model MUST cite `avg_daa ≥ chain_median_daa` in the reasoning. Otherwise use `StrategyExecutor` or `MEVBot`.
+
+The same primacy was reinforced in `HOW TO CLASSIFY` so the model sees `avg_daa` as a primary public/private signal before reading any path.
+
+### Round 3 (v3) — PATH 0 Identity Gate
+
+The v3 eval revealed that the model was still anchoring on PRIVATE caller diversity in PATH G1 and skipping the EXCEPTION clause that mentioned `github.has_valid_repo`. Examples:
+- `0x00003bf45c…` (Curve PMM, github=true) → still classified `trading / StrategyExecutor`.
+- `0xee7ae85f2…` (verified single-owner USDC vault) → classified `stablecoin` instead of `trading`.
+
+Buried EXCEPTIONS aren't enough — the check has to run before any caller-based path.
+
+**Fix.** `backend/labeling/ai_classifier.py` now defines `PATH 0 — Identity Gate` that runs BEFORE PATH A. If `is_verified=True OR github.has_valid_repo=true`, PATH G1/G2/G3 trading defaults are explicitly disabled. The single exception (verified LP managers) is preserved. The repo-name owner-extraction heuristic is also stated here (e.g. `TransitSwapRouterV5` → transit-finance).
+
+## Code-level fix — Blockscout token gate
+
+`backend/labeling/ai_classifier.py:907-927` (the `novel_tokens` augmentation block).
+
+Previously every token in `bs_token_transfers` was unconditionally appended to `novel_tokens`. Simple proxies / forwarders that pass through random ERC20 transfers ended up named after the largest passing-through token, swamping trace-derived identity (P2 in the original validation findings).
+
+After the change, a Blockscout token is promoted to `novel_tokens` only if its name or symbol also appears in the trace-decoded contract names, OR the trace set is entirely empty (no competing identity). Full `bs_token_display` still flows into the prompt as context — this is gating the augmentation only, not removing visibility.
+
+## Sentinel (`_is_protocol_likely`) — already correct
+
+`backend/labeling/automated_labeler.py:538`.
+
+Reviewed during this work. Already covers all three positive overrides identified in the eval:
+- `is_verified=true` → `True` (line 549).
+- `novel_tokens` non-empty → `True` (line 562).
+- `github.has_valid_repo=true` → `True` (line 589, via the `log_signals['has_valid_repo']` plumbing at line 637).
+
+No change needed.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `backend/labeling/ai_classifier.py` | Schema fix (enum + property_ordering); new PATH 0 Identity Gate; PATH A protocol corrections (Socket/OffchainAggregator/Factory/etc.); PATH O updatePrices/fulfillment fns + sticky rule; PATH G1/G2 EXCEPTIONs extended to github + LP exception-to-exception; PATH G3 stablecoin/airdrop/avg_daa rules; new avg_daa Discriminator section; name-derivation priority + composite-forbid; BS token augment gate. |
+| `backend/labeling/automated_labeler.py` | No changes (sentinel already correct). |
+| `backend/labeling/eval/` | New package: `context_cache.py`, `eval_human_corrections.py`, `re_eval_prompt.py`, `README.md` — the self-critique loop driving these iterations. |
+| `docs/classifier_prompt_improvements_2026-04-28.md` | This report. |
+
+## How to re-run the eval
+
+```bash
+# Cache is already warm (127 rows enriched on 2026-04-27).
+python backend/labeling/eval/eval_human_corrections.py --run-id v4_<date>
+
+# Reports land at backend/local/eval_results/<run_id>/{per_row.jsonl, report.md}.
+```
+
+The `per_row.jsonl` is shaped as `{state, action, reward}` analogues for downstream RL — once `contract_label_features` + `contract_label_review` are populated, the dump-loader inside the orchestrator can swap to a SQL query without other structural changes.
+
+## Known residual issues (v3)
+
+- Stablecoin rule still occasionally over-fires on private contracts that move USDC as part of a single-owner vault (PATH 0 Identity Gate should fix most of these on the next eval).
+- Owner extraction from `github.has_valid_repo` URL is named in PATH 0 but not yet wired with strong heuristics for repo-name → owner-slug mapping. Best handled when the linked repository URL becomes part of the classifier input rather than a boolean.
+- ~10 / 127 rows still produce meta-eval JSON parse failures from `gemini-2.5-pro` with very long oracle/bridge contracts. Acceptable noise floor; the per-row JSONL records `_meta_error` so they can be re-evaluated.
+
+## What we did NOT change
+
+- Sentinel `_is_protocol_likely` — already covers `is_verified`, `novel_tokens`, `has_valid_repo`. No edits made.
+- The 22-key signal extension to `classify_contract()`'s return dict (TODO at `ai_classifier.py:~1095`) — not required for prompt iteration, but it would let the meta-evaluator see exact path-side signals (current state shows the model only some of them via `RAW_SIGNALS` derived from cached context). Worth doing before the next eval round.
+- The downstream `contract_label_features` / `contract_label_review` write paths — separate workstream, tracked in the prior plan.

--- a/docs/contract_label_features_schema.md
+++ b/docs/contract_label_features_schema.md
@@ -343,12 +343,14 @@ CREATE INDEX ON public.contract_label_review (owner_was_assigned)   WHERE owner_
 
 | Component | Status |
 |---|---|
-| `ai_classifier.py` — extend return dict with pre-computed signals | **TODO** — see `TODO(contract_label_features)` comment at line ~994 |
-| `automated_labeler.py` — write to `contract_label_features` after classification | **TODO** — see `TODO(contract_label_features)` comment at line ~895 |
-| `db_connector.py` — `upsert_contract_label_features()` | **TODO** — see `TODO(contract_label_features)` comment after `get_oli_labels()` |
-| `db_connector.py` — `insert_contract_label_review()` + `get_contract_label_features()` | **TODO** — same comment block |
-| `oli_airtable.py` `airtable_read_automated_labels()` — diff capture | **TODO** — see `TODO(contract_label_review)` comment at line ~564 |
-| `oli_airtable.py` `airtable_read_label_pool_reattest()` — diff capture | **TODO** — see `TODO(contract_label_review)` comment at line ~504 |
-| Airtable "Label Pool Automated" — add `gtp_owner_project` + `gtp_no_owner_project` fields | **TODO** — manual Airtable UI change |
-| Airtable "Label Pool Reattest" — add `gtp_no_owner_project` field | **TODO** — manual Airtable UI change |
-| Run table DDLs on DB | **TODO** — after code changes are deployed |
+| `ai_classifier.py` — extend return dict with pre-computed signals | **DONE** — main + fallback paths attach 22 signal keys |
+| `automated_labeler.py` — write to `contract_label_features` after classification | **DONE** — `_build_feature_row()` + `upsert_contract_label_features()` call before output write |
+| `db_connector.py` — `upsert_contract_label_features()` | **DONE** |
+| `db_connector.py` — `insert_contract_label_review()` + `get_contract_label_features()` | **DONE** |
+| `oli_airtable.py` `airtable_read_automated_labels()` — diff capture + human-override coalesce | **DONE** — review row written before `oli.submit_label`; human edits override AI tags |
+| `oli_airtable.py` `airtable_read_label_pool_reattest()` — diff capture | **NOT WIRED** (intentional) — diffs only flow from "Label Pool Automated" to keep validation surface concentrated |
+| `airtable_functions.read_all_label_pool_automated()` — new sibling of `read_all_label_pool_reattest()` | **DONE** — Label-Pool-Automated-only fn that coalesces `contract_name_human` + `new_usage_category` over AI, exposes `temp_owner_project` (review-only, never attested), drops `owner_project` when `gtp_no_owner_project=True`. Reattest reader left untouched. |
+| Validation surface consolidated to "Label Pool Automated" | **DONE** — `airtable_write_protocol_likely_to_automated()` re-targets the protocol-likely surfacer to Label Pool Automated; reviewer assigns owner/temp/no-owner there |
+| Airtable "Label Pool Automated" — `gtp_owner_project_confirmed` + `gtp_no_owner_project` fields | **DONE** — derived: `confirmed = (owner_project filled OR temp_owner_project filled)`. `gtp_no_owner_project` checkbox already exists |
+| Run table DDLs on DB | **TODO** — apply `backend/db_migrations/001_contract_label_features.sql` to prod once |
+| `google-genai==1.72.0` in `backend/requirements-new.txt` | **DONE** — restored after merge regression |

--- a/docs/contract_label_features_schema.md
+++ b/docs/contract_label_features_schema.md
@@ -1,96 +1,126 @@
-# Contract Label Features — Database Schema
+# Contract Label Features & Review — Database Schema
 
-This document describes the proposed `contract_label_features` table.
-It captures every signal computed during the automated labeling pipeline per contract,
-alongside the AI output and any available OLI ground truth.
-The intended use is training and evaluating ML models for smart contract classification.
-
----
-
-## Primary Key
-
-`(address, origin_key)` — one row per contract per chain.
-Re-running the labeler on the same contract should upsert (update `labeled_at` and all signal columns).
+This document describes the two-table design for capturing AI contract classification signals
+and human review corrections. The intended use is training ML models, evaluating classifier
+performance, and building ground truth for supervised learning.
 
 ---
 
-## Column Groups
+## Overview: Two-Table Design
 
-### 1. Identity
+| Table | Purpose | Written by | Primary key |
+|---|---|---|---|
+| `contract_label_features` | Feature store — all signals computed per run + AI output | `automated_labeler.py` | `(address, origin_key)` |
+| `contract_label_review` | Review audit log — diff between AI output and GTP-attested result | `oli_airtable.py` DAG | `id` (serial) |
 
-| Column | Type | Description |
+**ML join pattern:**
+```sql
+SELECT f.*, r.gtp_usage_category, r.gtp_owner_project, r.name_was_changed, r.category_was_changed
+FROM public.contract_label_features f
+LEFT JOIN public.contract_label_review r USING (address, origin_key)
+```
+
+---
+
+## Pipeline Context
+
+### Attester addresses
+| Address | Role | Trust level |
 |---|---|---|
-| `address` | `bytea` | Contract address (PK) |
-| `origin_key` | `varchar` | Chain identifier, e.g. `base`, `optimism` (PK) |
-| `labeled_at` | `timestamptz` | Timestamp when the AI classifier ran |
-| `blockscout_name` | `varchar` | Raw contract name from Blockscout |
-| `is_verified` | `bool` | Source code verified on Blockscout |
-| `is_proxy` | `bool` | Contract is a proxy pattern |
-| `impl_address` | `bytea` | Implementation address (null if not proxy) |
-| `impl_name` | `varchar` | Resolved implementation contract name |
-| `impl_verified` | `bool` | Implementation source verified |
-| `has_github_repo` | `bool` | Contract address found in a GitHub repo |
-| `github_repo_count` | `int` | Number of repos referencing this address |
+| `0xaDbf2b56995b57525Aa9a45df19091a2C5a2A970` | Automated labeler — general | Low (AI-generated) |
+| `0xab81887E560e7C7b5993cE45D1c584d7FC22e898` | Automated labeler — trading specialist | Low (AI-generated) |
+| `0xA725646C05E6BB813D98C5ABB4E72DF4BCF00B56` | GTP main attester (re-attestation key) | High (human-approved) |
+
+### Approval flows that generate `contract_label_review` rows
+
+| Airtable table | `review_source` value | What human does |
+|---|---|---|
+| "Label Pool Automated" | `airtable_automated` | Approves/edits `contract_name` and `usage_category`; optionally sets `gtp_owner_project` or checks `gtp_no_owner_project` |
+| "Label Pool Reattest" | `airtable_reattest` | Assigns `owner_project` for protocol-likely contracts; optionally checks `gtp_no_owner_project` |
+| "Unlabelled" | `airtable_unlabelled` | Manual labeling — no AI output to diff against |
 
 ---
 
-### 2. Activity Metrics
+## Table 1: `contract_label_features`
+
+One row per contract per chain. Upserted on every labeling run (`ON CONFLICT (address, origin_key) DO UPDATE`).
+Written by `automated_labeler.py` BEFORE OLI attestation, so even contracts below the 0.5 confidence
+threshold are captured (valuable training data for hard cases).
+
+> **TODO:** Table does not exist yet. DDL at bottom of this document.  
+> **TODO:** `automated_labeler.py` does not write to this table yet. See `TODO(contract_label_features)` comment at line ~895.  
+> **TODO:** `ai_classifier.py` does not return pre-computed signals yet. See `TODO(contract_label_features)` comment at line ~994.
+
+### 1.1 Identity
+
+| Column | Type | Source | Description |
+|---|---|---|---|
+| `address` | `bytea` | `blockspace_fact_contract_level.address` | Contract address (PK) |
+| `origin_key` | `varchar` | pipeline | Chain identifier, e.g. `base`, `optimism` (PK) |
+| `labeled_at` | `timestamptz` | pipeline | When this labeling run completed |
+| `blockscout_name` | `varchar` | `BlockscoutAPI_Async.get_contract_info()` | Raw name from Blockscout (may be generic proxy name — see `is_proxy`) |
+| `is_verified` | `bool` | Blockscout | Source code verified on Blockscout |
+| `is_proxy` | `bool` | Blockscout | Contract is a proxy pattern (ERC-1967, Transparent, UUPS, etc.) |
+| `impl_address` | `bytea` | Blockscout `implementations[]` | Implementation address (null if not proxy) |
+| `impl_name` | `varchar` | Blockscout implementation lookup | Resolved implementation contract name |
+| `impl_verified` | `bool` | Blockscout | Implementation source verified |
+| `has_github_repo` | `bool` | `GitHubAPI_Async.search_contract_address()` | Contract address found in a public GitHub repo |
+| `github_repo_count` | `int` | GitHub | Number of repos referencing this address |
+
+### 1.2 Activity Metrics
 
 Aggregated from `blockspace_fact_contract_level` over `metric_day_range` days.
+Computed in `db_connector.get_unlabelled_contracts_v2()`.
 
 | Column | Type | Description |
 |---|---|---|
-| `metric_day_range` | `int` | Window used for aggregation (e.g. 7, 30) |
+| `metric_day_range` | `int` | Window used for aggregation (default 7) |
 | `txcount` | `int` | Total transactions in window |
 | `gas_eth` | `numeric` | Total gas fees in ETH |
 | `avg_daa` | `numeric` | Average daily active addresses |
-| `avg_gas_per_tx` | `numeric` | Gas ETH / txcount |
-| `rel_cost` | `numeric` | Median tx fee vs chain median (1.0 = at median) |
-| `success_rate` | `numeric` | Fraction of successful transactions (0.0–1.0) |
-| `daa_ratio` | `numeric` | avg_daa / txcount × 100 — proxy for automation vs human use |
+| `avg_gas_per_tx` | `numeric` | `gas_eth / txcount` |
+| `rel_cost` | `numeric` | Contract median tx fee / chain median tx fee (1.0 = at chain median) |
+| `success_rate` | `numeric` | Fraction of successful transactions (0.0–1.0); null if unavailable |
+| `daa_ratio` | `numeric` | `avg_daa / txcount × 100` — proxy for human use vs automation |
 
----
+### 1.3 Caller Diversity
 
-### 3. Caller Diversity
-
-Derived from the sampled transaction traces.
+Derived from sampled Tenderly traces inside `classify_contract()`.
 
 | Column | Type | Description |
 |---|---|---|
-| `caller_diversity_pct` | `numeric` | Unique callers / sampled txns × 100 |
-| `unique_callers` | `int` | Distinct sender addresses in sample |
-| `total_traces_sampled` | `int` | Total transactions sampled (sample size context) |
-| `caller_diversity_label` | `varchar` | `PRIVATE` (≤20%) / `KEEPER` (20–80%) / `PUBLIC` (≥80% + DAA threshold) |
+| `caller_diversity_pct` | `numeric` | Unique caller addresses / sampled txns × 100 |
+| `caller_diversity_label` | `varchar` | `PRIVATE` (≤20%) / `KEEPER` (20–80%) / `PUBLIC` (≥80% + DAA threshold) / `UNKNOWN` |
+| `unique_callers` | `int` | Distinct sender addresses in trace sample |
+| `total_traces_sampled` | `int` | Number of transactions sampled (context for diversity %) |
 
----
+### 1.4 Trace-Derived Protocol Signals
 
-### 4. Trace-Derived Protocol Signals
-
-Computed from Tenderly traces (depth-0/1 direct calls).
+Computed from Tenderly traces at depth-0/1 direct calls inside `classify_contract()`.
+`novel_tokens` / `common_tokens` also augmented from Blockscout token-transfer endpoint.
 
 | Column | Type | Description |
 |---|---|---|
-| `novel_tokens` | `text[]` | ERC20 token names seen in ≥50% of traces, not common infra (WETH/USDC/etc.) — high signal for protocol identity |
-| `common_tokens` | `text[]` | ERC20 token names seen in ≥50% of traces that ARE common infra — low signal |
-| `bs_token_transfers` | `jsonb` | Raw Blockscout token-transfer records: `[{token_name, token_symbol, token_type}]` |
-| `matched_routers` | `text[]` | Named DEX routers called directly (e.g. `UniswapV3Router`) |
+| `novel_tokens` | `text[]` | ERC20 names seen in ≥50% of traces, NOT in common-infra list (WETH/USDC/etc.) — HIGH signal for protocol identity |
+| `common_tokens` | `text[]` | ERC20 names seen in ≥50% of traces that ARE common infra — low signal |
+| `bs_token_transfers` | `jsonb` | Blockscout token-transfer records: `[{token_name, token_symbol, token_type}]` — more reliable than trace-decoded names |
+| `matched_routers` | `text[]` | Named DEX routers called directly, e.g. `UniswapV3Router` |
 | `matched_dex_pools` | `text[]` | AMM pool contracts called directly |
 | `calls_into_dex_pool_swap` | `bool` | Made state-changing swap calls into AMM pools |
 | `matched_lending` | `text[]` | Lending protocols called (Aave, Compound, Morpho, etc.) |
 | `matched_staking` | `text[]` | Staking/gauge contracts called (Gauge, Voter, MasterChef, etc.) |
 | `matched_bridges` | `text[]` | Bridge protocols called (Relay, LayerZero, Stargate, etc.) |
-| `matched_oracle_fns` | `text[]` | Oracle function calls detected (latestAnswer, getPrice, etc.) |
-| `delegates_to` | `varchar` | Named contract this contract delegates to |
-| `raw_delegate` | `bool` | EIP-1167 minimal proxy / clone |
-| `all_traces_empty` | `bool` | All sampled traces had no call graph |
-| `traces_only_raw_opcodes` | `bool` | Traces had no decoded function or contract names |
-| `named_contracts_in_traces` | `text[]` | All named contracts seen anywhere in traces |
+| `matched_oracle_fns` | `text[]` | Oracle function calls detected at any depth (latestAnswer, getPrice, etc.) |
+| `delegates_to` | `varchar` | Named contract this contract delegates to (EIP-1167 target name) |
+| `raw_delegate` | `bool` | EIP-1167 minimal proxy / clone (raw address delegate, no name) |
+| `all_traces_empty` | `bool` | All sampled traces had no call graph (contract may only receive ETH) |
+| `traces_only_raw_opcodes` | `bool` | Traces had no decoded function or contract names (unverified + unrecognized ABI) |
+| `named_contracts_in_traces` | `text[]` | All named contracts seen anywhere in traces (any depth) |
 
----
+### 1.5 Log Signals
 
-### 5. Log Signals
-
-Decoded from the contract's own emitted events (Blockscout logs endpoint).
+Decoded from the contract's own emitted events via `BlockscoutAPI_Async.get_address_logs()` +
+`decode_log_signals()` in `ai_classifier.py`.
 
 | Column | Type | Description |
 |---|---|---|
@@ -101,55 +131,170 @@ Decoded from the contract's own emitted events (Blockscout logs endpoint).
 | `log_has_erc4337` | `bool` | UserOperationEvent / AccountDeployed (account abstraction) |
 | `log_has_staking` | `bool` | Staking-related events |
 | `log_has_governance` | `bool` | ProposalCreated / VoteCast |
-| `log_category_hints` | `text[]` | Derived category signals from event patterns |
+| `log_category_hints` | `text[]` | Category signals derived from event patterns |
 | `log_top_events` | `jsonb` | Event name → occurrence count, e.g. `{"Swap": 41, "Transfer": 12}` |
 
----
+### 1.6 AI Output
 
-### 6. AI Output
-
-The label and metadata produced by the Gemini classifier.
+The label produced by `classify_contract()` in `ai_classifier.py` (Gemini model).
 
 | Column | Type | Description |
 |---|---|---|
-| `ai_usage_category` | `varchar` | Assigned OLI usage category ID (e.g. `dex`, `token_contract`) |
-| `ai_contract_name` | `varchar` | Assigned human-readable protocol/contract name |
+| `ai_contract_name` | `varchar` | Assigned human-readable name (max 50 chars) |
+| `ai_usage_category` | `varchar` | Assigned OLI category ID, e.g. `dex`, `token_contract`, `trading` |
 | `ai_confidence` | `numeric` | Model confidence 0.0–1.0 |
-| `ai_reasoning` | `text` | Free-text reasoning from the model |
-| `ai_model` | `varchar` | Model version used (e.g. `gemini-2.5-flash`) |
-| `sentinel_fired` | `bool` | Whether the rule-based sentinel short-circuited the AI call |
-| `sentinel_category` | `varchar` | Category assigned by sentinel (null if sentinel did not fire) |
+| `ai_reasoning` | `text` | Classifier reasoning string (`PATH X[subpath]: signal=val → category`) |
+| `ai_model` | `varchar` | Model version, e.g. `gemini-2.5-flash` |
+| `ai_owner_project_likely` | `bool` | `_is_protocol_likely()` sentinel result — TRUE means the contract likely belongs to a named protocol and should be surfaced for `owner_project` assignment |
+| `sentinel_fired` | `bool` | TRUE if the rule-based sentinel short-circuited the AI call |
+| `sentinel_category` | `varchar` | Category assigned by sentinel (null if AI ran normally) |
 
 ---
 
-### 7. OLI Ground Truth
+## Table 2: `contract_label_review`
 
-Available only for contracts that have been attested in the OLI label pool.
-Use `is_human_label = true` rows as the high-quality supervised training set.
+Append-only audit log. One row per approval event. A contract can have multiple review rows
+(re-labeled across weeks as new signals emerge or the label is corrected).
+
+Written by `oli_airtable.py` tasks immediately before `oli.submit_label()` with `OLI_gtp_pk`.
+
+> **TODO:** Table does not exist yet. DDL at bottom of this document.  
+> **TODO:** `airtable_read_automated_labels()` does not write to this table yet. See `TODO(contract_label_review)` comment in `oli_airtable.py` line ~564.  
+> **TODO:** `airtable_read_label_pool_reattest()` does not write to this table yet. See `TODO(contract_label_review)` comment in `oli_airtable.py` line ~504.  
+> **TODO:** Airtable "Label Pool Automated" needs two new fields: `gtp_owner_project` (text) + `gtp_no_owner_project` (checkbox).  
+> **TODO:** Airtable "Label Pool Reattest" needs new field: `gtp_no_owner_project` (checkbox).
 
 | Column | Type | Description |
 |---|---|---|
-| `oli_usage_category` | `varchar` | Confirmed OLI usage category |
-| `oli_owner_project` | `varchar` | Protocol / project name from OLI |
-| `oli_confirmed_at` | `timestamptz` | When the attestation was confirmed |
-| `is_human_label` | `bool` | `true` = manually attested, `false` = automated attester (noisy label) |
+| `id` | `serial` | PK (append-only log) |
+| `address` | `bytea` | Contract address (FK → contract_label_features) |
+| `origin_key` | `varchar` | Chain (FK → contract_label_features) |
+| `labeled_at` | `timestamptz` | When the AI ran — from `contract_label_features.labeled_at` |
+| `reviewed_at` | `timestamptz` | When the GTP attester re-attested |
+| `review_source` | `varchar` | `airtable_automated` / `airtable_reattest` / `airtable_unlabelled` |
+| **AI values (frozen at labeling time)** | | |
+| `ai_contract_name` | `varchar` | What the AI assigned — from `contract_label_features` |
+| `ai_usage_category` | `varchar` | What the AI assigned — from `contract_label_features` |
+| `ai_confidence` | `numeric` | AI confidence at labeling time |
+| `ai_owner_project_likely` | `bool` | Was `protocol-contract-likely` sentinel fired |
+| **GTP-attested values (what was ultimately signed by `OLI_gtp_pk`)** | | |
+| `gtp_contract_name` | `varchar` | Human-corrected name; NULL = kept AI name unchanged |
+| `gtp_usage_category` | `varchar` | Human-corrected category; NULL = kept AI category unchanged |
+| `gtp_owner_project` | `varchar` | Protocol slug assigned by human (e.g. `uniswap`, `aave`); NULL = no owner assigned |
+| `gtp_no_owner_project` | `bool` | TRUE = human explicitly confirmed this contract has no protocol owner — prevents re-surfacing for owner assignment |
+| **Derived diff flags (generated columns)** | | |
+| `name_was_changed` | `bool` | `gtp_contract_name IS NOT NULL` |
+| `category_was_changed` | `bool` | `gtp_usage_category IS NOT NULL` |
+| `owner_was_assigned` | `bool` | `gtp_owner_project IS NOT NULL` |
 
 ---
 
-## Recommended Indexes
+## DDL
 
 ```sql
--- Primary key
-PRIMARY KEY (address, origin_key)
+-- ── Feature store ────────────────────────────────────────────────────────────
+CREATE TABLE public.contract_label_features (
+    -- Identity
+    address               bytea        NOT NULL,
+    origin_key            varchar      NOT NULL,
+    labeled_at            timestamptz  NOT NULL,
+    blockscout_name       varchar,
+    is_verified           bool         DEFAULT false,
+    is_proxy              bool         DEFAULT false,
+    impl_address          bytea,
+    impl_name             varchar,
+    impl_verified         bool         DEFAULT false,
+    has_github_repo       bool         DEFAULT false,
+    github_repo_count     int          DEFAULT 0,
+    -- Activity metrics
+    metric_day_range      int,
+    txcount               bigint,
+    gas_eth               numeric,
+    avg_daa               numeric,
+    avg_gas_per_tx        numeric,
+    rel_cost              numeric,
+    success_rate          numeric,
+    daa_ratio             numeric,
+    -- Caller diversity
+    caller_diversity_pct    numeric,
+    caller_diversity_label  varchar,
+    unique_callers          int,
+    total_traces_sampled    int,
+    -- Trace-derived protocol signals
+    novel_tokens              text[],
+    common_tokens             text[],
+    bs_token_transfers        jsonb,
+    matched_routers           text[],
+    matched_dex_pools         text[],
+    calls_into_dex_pool_swap  bool     DEFAULT false,
+    matched_lending           text[],
+    matched_staking           text[],
+    matched_bridges           text[],
+    matched_oracle_fns        text[],
+    delegates_to              varchar,
+    raw_delegate              bool     DEFAULT false,
+    all_traces_empty          bool     DEFAULT false,
+    traces_only_raw_opcodes   bool     DEFAULT false,
+    named_contracts_in_traces text[],
+    -- Log signals
+    log_has_access_control   bool DEFAULT false,
+    log_has_token_transfers  bool DEFAULT false,
+    log_has_swaps            bool DEFAULT false,
+    log_has_bridge_events    bool DEFAULT false,
+    log_has_erc4337          bool DEFAULT false,
+    log_has_staking          bool DEFAULT false,
+    log_has_governance       bool DEFAULT false,
+    log_category_hints       text[],
+    log_top_events           jsonb,
+    -- AI output
+    ai_contract_name        varchar,
+    ai_usage_category       varchar,
+    ai_confidence           numeric,
+    ai_reasoning            text,
+    ai_model                varchar,
+    ai_owner_project_likely bool    DEFAULT false,
+    sentinel_fired          bool    DEFAULT false,
+    sentinel_category       varchar,
+    PRIMARY KEY (address, origin_key)
+);
 
--- Slice by chain + time for training data queries
-CREATE INDEX ON contract_label_features (origin_key, labeled_at DESC);
+CREATE INDEX ON public.contract_label_features (origin_key, labeled_at DESC);
+CREATE INDEX ON public.contract_label_features (ai_confidence) WHERE ai_confidence < 0.7;
+CREATE INDEX ON public.contract_label_features (ai_usage_category);
 
--- Filter to human-confirmed ground truth
-CREATE INDEX ON contract_label_features (is_human_label) WHERE is_human_label = true;
 
--- Filter to low-confidence AI outputs (most informative for active learning)
-CREATE INDEX ON contract_label_features (ai_confidence) WHERE ai_confidence < 0.7;
+-- ── Review audit log ─────────────────────────────────────────────────────────
+CREATE TABLE public.contract_label_review (
+    id                    serial       PRIMARY KEY,
+    address               bytea        NOT NULL,
+    origin_key            varchar      NOT NULL,
+    labeled_at            timestamptz,
+    reviewed_at           timestamptz  NOT NULL,
+    review_source         varchar      NOT NULL,
+    -- AI values frozen at labeling time
+    ai_contract_name        varchar,
+    ai_usage_category       varchar,
+    ai_confidence           numeric,
+    ai_owner_project_likely bool,
+    -- GTP-attested values
+    gtp_contract_name    varchar,
+    gtp_usage_category   varchar,
+    gtp_owner_project    varchar,
+    gtp_no_owner_project bool         DEFAULT false,
+    -- Diff flags
+    name_was_changed     bool GENERATED ALWAYS AS
+                           (gtp_contract_name IS NOT NULL) STORED,
+    category_was_changed bool GENERATED ALWAYS AS
+                           (gtp_usage_category IS NOT NULL) STORED,
+    owner_was_assigned   bool GENERATED ALWAYS AS
+                           (gtp_owner_project IS NOT NULL) STORED
+);
+
+CREATE INDEX ON public.contract_label_review (address, origin_key);
+CREATE INDEX ON public.contract_label_review (reviewed_at DESC);
+CREATE INDEX ON public.contract_label_review (name_was_changed)     WHERE name_was_changed     = true;
+CREATE INDEX ON public.contract_label_review (category_was_changed) WHERE category_was_changed = true;
+CREATE INDEX ON public.contract_label_review (owner_was_assigned)   WHERE owner_was_assigned   = true;
 ```
 
 ---
@@ -158,30 +303,52 @@ CREATE INDEX ON contract_label_features (ai_confidence) WHERE ai_confidence < 0.
 
 ### Feature encoding
 
-- **`text[]` columns** — one-hot encode with `unnest()` at query time or embed as bag-of-words. Do not flatten to individual boolean columns in the DB; the array form is more flexible.
-- **`jsonb` columns** (`bs_token_transfers`, `log_top_events`) — extract structured features at training time. Token names are high-cardinality free text; consider embedding them separately (e.g. token name → embedding vector).
-- **`ai_confidence`** — use as sample weight during training, not as a filter. Low-confidence rows are often the hardest and most informative cases.
+- **`text[]` columns** — one-hot at query time with `unnest()`, or embed as bag-of-words. Do not flatten in DB.
+- **`jsonb` columns** (`bs_token_transfers`, `log_top_events`) — extract structured features at training time. Token names are high-cardinality free text; embed separately.
+- **`ai_confidence`** — use as sample weight, not a filter. Low-confidence rows are the hardest and most informative training cases.
+- **`daa_ratio`** — derived feature already computed (`avg_daa / txcount × 100`); captures automation signal without requiring both columns.
 
 ### Label quality tiers
 
 | Tier | Filter | Use for |
 |---|---|---|
-| High quality | `is_human_label = true` | Validation, fine-tuning |
-| Medium quality | `is_human_label = false AND ai_confidence >= 0.85` | Pre-training, weak supervision |
-| Exploratory | `ai_confidence < 0.7` | Active learning, error analysis |
+| **High quality** | `r.gtp_usage_category IS NOT NULL OR r.gtp_owner_project IS NOT NULL` | Validation set, fine-tuning |
+| **Medium quality** | `f.ai_confidence >= 0.85 AND r.id IS NULL` | Pre-training with weak labels |
+| **Error analysis** | `r.category_was_changed = true` | Where AI got it wrong |
+| **Hard cases** | `f.ai_confidence < 0.7` | Active learning, boundary cases |
+| **Owner ground truth** | `r.owner_was_assigned = true` | Protocol identity supervision |
+| **Explicit no-owner** | `r.gtp_no_owner_project = true` | Negative examples for owner classifier |
 
 ### Model ideas
 
-| Task | Input features | Target |
+| Task | Features | Target |
 |---|---|---|
-| Category classifier | All signal columns | `ai_usage_category` or `oli_usage_category` |
-| Confidence predictor | All signal columns | `ai_confidence` — find systematic over/under-confidence |
+| Category classifier | All `contract_label_features` signal columns | `ai_usage_category` (weak) or `gtp_usage_category` (strong) |
+| Name correction predictor | Feature signals | `name_was_changed` — predict when AI name will be wrong |
+| Category correction predictor | Feature signals | `category_was_changed` — predict AI category errors |
+| Owner project classifier | `novel_tokens`, `matched_*`, `log_*`, `ai_usage_category` | `gtp_owner_project` |
 | Sentinel bypass | Cheap signals only (metrics + log flags, no traces) | Category — skip Gemini for obvious cases |
-| Anomaly detection | All feature vectors | Unsupervised — flag contracts that fit no known cluster |
-| Label correction | Features where `ai_category != oli_category` | Error pattern analysis |
+| Confidence calibration | Features + `ai_confidence` | `category_was_changed` — is AI confidence predictive of errors? |
 
 ### What is NOT stored here
 
-- Raw transaction traces (too large; stored transiently during enrichment only)
-- Raw Blockscout API responses (derive features from them instead)
-- ABI or source code (too large; use Blockscout `is_verified` + `blockscout_name` as proxies)
+- Raw Tenderly traces — too large; computed transiently during enrichment
+- Raw Blockscout API responses — derive features from them instead  
+- ABI or source code — too large; `is_verified` + `blockscout_name` are the proxies
+- Revocation events — tracked separately in `public.labels` (OLI standard)
+
+---
+
+## Implementation Status
+
+| Component | Status |
+|---|---|
+| `ai_classifier.py` — extend return dict with pre-computed signals | **TODO** — see `TODO(contract_label_features)` comment at line ~994 |
+| `automated_labeler.py` — write to `contract_label_features` after classification | **TODO** — see `TODO(contract_label_features)` comment at line ~895 |
+| `db_connector.py` — `upsert_contract_label_features()` | **TODO** — see `TODO(contract_label_features)` comment after `get_oli_labels()` |
+| `db_connector.py` — `insert_contract_label_review()` + `get_contract_label_features()` | **TODO** — same comment block |
+| `oli_airtable.py` `airtable_read_automated_labels()` — diff capture | **TODO** — see `TODO(contract_label_review)` comment at line ~564 |
+| `oli_airtable.py` `airtable_read_label_pool_reattest()` — diff capture | **TODO** — see `TODO(contract_label_review)` comment at line ~504 |
+| Airtable "Label Pool Automated" — add `gtp_owner_project` + `gtp_no_owner_project` fields | **TODO** — manual Airtable UI change |
+| Airtable "Label Pool Reattest" — add `gtp_no_owner_project` field | **TODO** — manual Airtable UI change |
+| Run table DDLs on DB | **TODO** — after code changes are deployed |


### PR DESCRIPTION
Closes out the OLI automated labeling pipeline by wiring human review corrections back into attestations correctly, adding a feature store + audit log, hardening the Gemini classifier through 3 eval rounds, and adding a self-critique eval framework for ongoing prompt improvement.

---

## 1. Airtable flow — separate concerns between Reattest and Automated

**Problem:** `airtable_read_automated_labels` was calling the same generic `read_all_label_pool_reattest` against the `Label Pool Automated` table. It worked mechanically (attested + deleted rows) but silently discarded human edits — `contract_name_human`, `new_usage_category`, `temp_owner_project`, and `gtp_no_owner_project` were all ignored.

**Fix:**
- `airtable_functions.py`: new `read_all_label_pool_automated()` — coalesces human edits over AI fields, snapshots AI baseline (`ai_contract_name`, `ai_usage_category`) before coalesce for diff capture, resolves all Airtable recIDs → slugs (origin_key, usage_category, owner_project), drops `owner_project` when `gtp_no_owner_project=True` or value is the `protocol-contract-likely` sentinel. `read_all_label_pool_reattest` is untouched.
- `oli_airtable.py`: `airtable_read_automated_labels` now calls `read_all_label_pool_automated`. Captures per-field diff before melt, writes to `contract_label_review`. `airtable_write_protocol_likely` target changed from `Label Pool Reattest` → `Label Pool Automated`.

---

## 2. DB layer — feature store + audit log

Two new tables (already exist in prod, empty):

**`contract_label_features`** — upserted after every classification batch. Stores all enrichment signals (blockscout, github, metrics), trace-derived protocol signals (matched routers/DEX/oracle/lending/bridges/staking), log signals, and the full AI output including 22 new signal keys added to the classifier return dict. Primary key `(address, origin_key)`.

**`contract_label_review`** — append-only. One row per Airtable approval. Snapshots AI values vs human corrections. Has generated boolean columns `name_was_changed`, `category_was_changed`, `owner_was_assigned` for fast querying of human override rates.

New `db_connector.py` methods: `upsert_contract_label_features`, `insert_contract_label_review`, `get_contract_label_features`.

---

## 3. Classifier prompt improvements (3 eval rounds, 127 rows)

**Root cause found in v1 baseline:** 80/127 rows had `usage_category="other"` — not a prompt quality issue. Gemini Flash was generating `usage_category` before `reasoning` (schema field ordering), then hedging to `other` because it had no prior context. Fix: `property_ordering=["reasoning","contract_name","usage_category","confidence"]` + `enum=valid_ids` constraint on `usage_category`.

**Result across 3 rounds:**

| Round | High-severity errors |
|---|---|
| v1 baseline | 79 |
| v2 (schema fix + avg_daa discriminator) | 41 (−48%) |
| v3 (PATH 0 gate + BS token gate + oracle fix) | 26 (−67% total) |

**Key prompt changes:**
- **PATH 0 Identity Gate** (new, pre-PATH A): `is_verified=True OR github.has_valid_repo=True` → blocks G1/G2/G3 trading defaults unconditionally.
- **avg_daa Discriminator section**: HIGH (≥ chain median) = public infra; LOW = can't be DEXAggregator.
- **PATH O**: added `updatePrices` to oracle fn list; sticky oracle rule (once oracle always oracle).
- **BS token gate**: BS token transfers only promoted to `novel_tokens` when name/symbol matches trace contract names (prevents false DEX/stablecoin hits from unrelated ERC-20 transfers).
- **G1/G2 LP exception**: if contract is itself an LP pool, trading category is valid even with github repo.
- Classifier return dict extended with 22 signal keys for downstream RL / feature store.

---

## 4. Self-critique eval pipeline (`backend/labeling/eval/`)

New package for ongoing prompt improvement:
- **`context_cache.py`**: on-chain context cache per `(address, origin_key)`, bulk warmer CLI (`--warm`).
- **`re_eval_prompt.py`**: `META_SYSTEM_INSTRUCTION` for Gemini 2.5 Pro — receives (AI output, human truth, raw signals, current system prompt), returns structured JSON with error diagnosis, root cause in prompt, and concrete edit proposals.
- **`eval_human_corrections.py`**: orchestrator — loads rows from JSON dump or DB, re-classifies with Flash (concurrency 5), meta-evaluates with Pro (concurrency 3), writes per-row JSONL ledger + aggregated markdown report. JSONL shaped as `{state, action, reward_signal}` for future RL ingestion.

```
python -m backend.labeling.eval.eval_human_corrections \
    --source {json,db} --run-id <id> [--limit N] [--skip-meta] [--refresh]
```

---

## 5. Documentation

- `docs/classifier_prompt_improvements_2026-04-28.md`: full report of all 3 eval rounds — error breakdown, root cause analysis, prompt edit rationale.
- `docs/contract_label_features_schema.md`: implementation status table updated — all TODOs marked done.
- `backend/db_migrations/` directory preserved for future `002_...sql` migrations.

---

## Breaking changes vs `oli/automated-labeler-v1`

- `google-genai==1.72.0` restored in `requirements-new.txt` (was silently dropped in merge from main — would have broken all Gemini calls).
- `airtable_write_protocol_likely` now targets `Label Pool Automated` instead of `Label Pool Reattest` — Airtable table must exist (it does).
- Classifier return dict shape changed (22 new keys) — any downstream code reading the exact key set needs updating.
