### PR TITLE
[total supply] fix block lookup for tokens deployed off-chain

### DIFF
--- a/backend/src/adapters/adapter_total_supply.py
+++ b/backend/src/adapters/adapter_total_supply.py
@@ -91,13 +91,13 @@ class AdapterTotalSupply(AbstractAdapter):
                         "fact_kpis",
                         filters={
                             "metric_key": "first_block_of_day",
-                            "origin_key": coin.origin_key
+                            "origin_key": coin.cs_deployment_origin_key
                         },
                         days=days
                     )
 
                     if block_df.empty:
-                        raise ValueError(f"Missing block data in fact_kpis for {coin.origin_key}. This is required to fetch total supply. Please run the utility_first_block DAG first to populate this data.")
+                        raise ValueError(f"Missing block data in fact_kpis for {coin.cs_deployment_origin_key}. This is required to fetch total supply. Please run the utility_first_block DAG first to populate this data.")
 
                     block_df = block_df.reset_index()
                     block_df['block_number'] = block_df['value'].astype(int)


### PR DESCRIPTION
The first_block_of_day lookup was using coin.origin_key (the L2) while the totalSupply() call executes against
coin.cs_deployment_origin_key (often Ethereum). For chains whose token lives on Ethereum (Mantle, Unichain, Linea, Worldchain, Polygon, Metis, Taiko, Starknet, Swell, Lisk, Loopring, Plume, Gravity, Fraxtal, Zircuit, etc.) this passed an L2 block number to Ethereum RPC, which returns either BlockNotFound or empty data, producing total_supply = 0 (or missing) and therefore FDV = 0 from 2026-05-05 onward.

Align both on cs_deployment_origin_key. No-op for chains where origin_key == cs_deployment_origin_key.