### PR TITLE
Full eval loop added + Skills + New system prompt for automated labeler

### DIFF
--- a/.claude/skills/airtable-labeling-patterns.md
+++ b/.claude/skills/airtable-labeling-patterns.md
@@ -1,0 +1,87 @@
+---
+name: airtable-labeling-patterns
+description: Use when working with Airtable in the labeling pipeline — linked-record resolution, human override coalesce, dedup before push, sentinel slug handling, diff capture, or questions about which table/reader/column to use.
+---
+
+# Airtable Labeling Patterns
+
+## Two tables, two readers — never mix them
+
+| Table | Reader | Flow |
+|-------|--------|------|
+| `Label Pool Automated` | `read_all_label_pool_automated` | GTP attester — human override coalesce happens here |
+| `Label Pool Reattest` | `read_all_label_pool_reattest` | External attester — no coalesce, read as-is |
+
+Both readers live in `backend/src/misc/airtable_functions.py`. Never point them at each other's table.
+
+## Human override coalesce (`read_all_label_pool_automated`)
+
+Applied automatically before the call site sees the data:
+
+```
+contract_name  ← contract_name_human  if human set it, else AI value
+usage_category ← new_usage_category   if human set it, else AI value
+```
+
+**AI baseline is snapshotted BEFORE coalesce** into `ai_contract_name` / `ai_usage_category` columns so diff capture downstream sees both sides.
+
+**Never edit the AI columns (`contract_name`, `usage_category`) in place** — always use `contract_name_human` / `new_usage_category` for human corrections.
+
+## Diff capture → `contract_label_review`
+
+Happens in `oli_airtable.py:airtable_automated_attest` at attest time:
+
+```python
+gtp_name = tags['contract_name']  if tags['contract_name'] != ai_name else None
+gtp_cat  = tags['usage_category'] if tags['usage_category'] != ai_cat  else None
+# Only set when human actually changed the AI value
+db_connector.insert_contract_label_review([{...}])
+```
+
+`ai_name`/`ai_cat` come from `contract_label_features` first, falling back to Airtable `ai_contract_name`/`ai_usage_category` if features write failed. The features-table path is stronger — it has the original classify_contract() output.
+
+## Linked-record fields
+
+Linked-record fields arrive as 1-element lists of `recXXX` IDs, not slugs:
+```python
+# Wrong — will write a recID as the slug
+owner_project = row['owner_project']
+
+# Right — resolve first
+owner_project = resolve_recid_to_slug(row['owner_project'][0])
+```
+
+When writing linked records BACK to Airtable, wrap the slug/recID in a list:
+```python
+df['owner_project'] = df['owner_project'].apply(lambda x: [x] if pd.notna(x) else None)
+```
+
+Resolution lives in `airtable_functions.py`. Chain recIDs use the `Chains` table `caip2` column. Project recIDs use the project name → recID mapping.
+
+## Dedup before push
+
+Always dedup against existing Airtable rows before `push_to_airtable()`. Duplicate rows accumulate silently — Airtable has no unique-key enforcement.
+
+Pattern used in `oli_airtable.py`:
+```python
+df_new = df_attested.merge(df_in_airtable, on=[...keys...], how='left', indicator=True)
+df_new = df_new[df_new['_merge'] == 'left_only'].drop(columns=['_merge'])
+```
+
+## Sentinel slug: `protocol-contract-likely`
+
+Set by `_is_protocol_likely()` in `automated_labeler.py` as `owner_project` placeholder when a contract looks like a public protocol but has no confirmed owner yet.
+
+**Rules:**
+- Surfaces the contract in `Label Pool Automated` for human `owner_project` / `temp_owner_project` / `gtp_no_owner_project` assignment.
+- **Must be dropped before OLI attestation** — it is not a valid OLI owner slug.
+- `read_all_label_pool_automated` drops it automatically: `df.loc[df['owner_project'] == 'protocol-contract-likely', 'owner_project'] = None`
+- `gtp_no_owner_project=True` also drops `owner_project` from the attestation payload.
+
+## `temp_owner_project`
+
+Free-text field, review-only. Stored in `contract_label_review`, never attested on-chain. Used by reviewers to note a suspected owner before an official OLI slug exists.
+
+## Push helper
+
+`push_to_airtable(table, df)` in `airtable_functions.py` — keeps list-like fields (linked-record arrays) untouched. Use this, not raw pyairtable batch calls, to avoid accidentally flattening linked records.

--- a/.claude/skills/automated-labeler-pipeline.md
+++ b/.claude/skills/automated-labeler-pipeline.md
@@ -1,0 +1,90 @@
+---
+name: automated-labeler-pipeline
+description: Use when debugging why contracts are missing, skipped, not enriched, not classified, not written to Airtable, or not attested — covers the full fetch→enrich→classify→features→airtable→attest stage map and its common failure modes.
+---
+
+# Automated Labeler Pipeline
+
+## Stage order
+
+Single `label_and_attest` Airflow task in `oli_automated_labeler.py`. Each stage can fail independently.
+
+```
+1. FETCH      automated_labeler.py:_fetch_unlabeled_contracts_v2()
+              SQL: blockspace_fact_contract_level → dedup against existing Airtable rows
+
+2. ENRICH     concurrent_contract_analyzer.py
+              Blockscout (name, verified, proxy) + GitHub + Tenderly traces + on-chain metrics
+              ⚠ contracts with EMPTY enrichment are SKIPPED at automated_labeler.py:619
+
+3. CLASSIFY   ai_classifier.py:classify_contract()
+              Builds prompt with pre-computed signals → Gemini Flash → {contract_name,
+              usage_category, confidence, reasoning, caller_diversity_label, novel_tokens, …}
+
+4. FEATURES   db_connector.upsert_contract_label_features() → public.contract_label_features
+              Idempotent on (address, origin_key). NON-FATAL — pipeline continues if this fails.
+
+5. AIRTABLE   _write_attested_to_airtable() → 'Label Pool Automated'
+              ALL rows land here for human review, regardless of confidence.
+
+6. ATTEST     oli.submit_label_bulk()
+              Only rows with confidence >= confidence_threshold (default 0.3) are submitted to OLI.
+```
+
+## Key files
+
+| File | Role |
+|------|------|
+| `backend/labeling/automated_labeler.py` | Orchestrator, enrichment skip logic, `_build_feature_row`, Airtable write |
+| `backend/labeling/ai_classifier.py` | Gemini classifier, signal pre-computation, prompt construction |
+| `backend/labeling/concurrent_contract_analyzer.py` | Parallel enrichment (Blockscout, GitHub, Tenderly) |
+| `backend/airflow/dags/oli/oli_automated_labeler.py` | Airflow DAG wrapper |
+
+## Enrichment skip logic (`automated_labeler.py:619`)
+
+A contract is skipped (never classified) when ALL of these are empty:
+- `blockscout.contract_name`
+- `blockscout.is_verified`
+- `traces`
+- `address_logs`
+
+These contracts would fall to PATH G0 → `other/AmbiguousContract 0.30` due to empty API returns — not genuine ambiguity. Skipping prevents polluting the attestation pool.
+
+**Symptom:** Contract never appears in Airtable or `contract_label_features`.
+**Debug:** Check Blockscout API key, Tenderly key, network connectivity to the chain's explorer.
+
+## `_is_protocol_likely()` (`automated_labeler.py:551`)
+
+Post-classification function that sets `owner_project = 'protocol-contract-likely'` when True.
+
+Decision order (first match wins):
+1. `blockscout.is_verified` → **True** (overrides everything — MEV bots rarely verify source)
+2. `category in ('trading', 'other')` → **False**
+3. `confidence < 0.50` → **False**
+4. `success_rate < 0.40` → **False**
+5. `novel_tokens` → **True** (gated after trading/other exclusion)
+6. `category in ('bridge','lending','erc4337','cc_communication','derivative','stablecoin','oracle')` → **True**
+7. Governance/staking/bridge/erc4337 log signals → **True**
+8. `confidence >= 0.65` → **True**, else **False**
+
+**`dex` is intentionally excluded from step 6** — unverified dex-classified contracts can be private strategies with public callers.
+
+## `_build_feature_row()` (`automated_labeler.py:680`)
+
+Converts the full classify_contract() return dict into the DB row shape for `contract_label_features`. 
+**Never remove keys from `classify_contract()` return dict** without updating this function — the DB upsert will silently drop the column data.
+
+## Chain median DAA
+
+`fetch_chain_median_daa()` uses module-level `_chain_median_cache`. One DB connection per chain per process. Do not call `DbConnector()` inside per-contract loops.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Contract missing from Airtable AND features | Enrichment returned empty → skipped at step 2 | Check API keys / Blockscout availability for that chain |
+| Contract in Airtable but missing from features | Step 4 (features write) failed non-fatally | Check logs for `upsert_contract_label_features` error; re-run backfill |
+| Contract in features but not attested on OLI | `confidence < 0.3` threshold | Lower `--confidence-threshold` or accept — low confidence is intentional |
+| `UndefinedTable` on features write | `public.<table>` prefix passed to `upsert_table` | Pass bare table name only — pangres double-qualifies otherwise |
+| `protocol-contract-likely` in OLI attestation | Sentinel not stripped before submit | `gtp_no_owner_project=True` or resolve to real slug before attesting |
+| "Database connection successful." flooding logs | `DbConnector()` called per contract | Bug — ensure `_chain_median_cache` is in scope, module not reloaded |

--- a/.claude/skills/classifier-eval-loop.md
+++ b/.claude/skills/classifier-eval-loop.md
@@ -1,0 +1,148 @@
+---
+name: classifier-eval-loop
+description: Use when the user asks about running, interpreting, or debugging the 3-phase classifier eval pipeline — critique, synthesize, verify, deploy. Triggers on questions about accuracy reports, per_row.jsonl, candidate prompts, phase failures, eval commands, or prompt versioning.
+---
+
+# Classifier Eval Loop
+
+## Overview
+
+RL-inspired pipeline that improves `_SYSTEM_INSTRUCTION` in `ai_classifier.py` by critiquing the Gemini classifier against human corrections from `contract_label_review`.
+
+**All eval code lives in:** `backend/labeling/eval/`
+**Prompt versions live in:** `backend/labeling/prompts/` (`versions.json`, `current.md`, `v1.md`, …)
+**Run outputs live in:** `backend/local/eval_results/<run-id>/`
+
+---
+
+## The 4 phases
+
+```
+Phase 1  CRITIQUE   DB only, no enrichment     per_row.jsonl + report.md
+Phase 2  SYNTHESIZE 1 Gemini Pro call           candidate_prompt.md + changelog
+Phase 3  VERIFY     re-enrich + Flash N×        accuracy_report.md
+         DEPLOY     patch ai_classifier.py      prompts/vN.md + versions.json
+```
+
+### Commands
+
+```bash
+# Smoke test first (3 rows, no Pro calls)
+python -m backend.labeling.eval.eval_human_corrections \
+    --source db --mode critique --run-id smoke --limit 3 --skip-meta
+
+# Full pipeline
+RUN=2026-$(date +%m-%d)_v1
+
+python -m backend.labeling.eval.eval_human_corrections \
+    --source db --mode critique --run-id $RUN
+
+python -m backend.labeling.eval.eval_human_corrections \
+    --mode synthesize --run-id $RUN
+
+# Review diff before verifying
+diff backend/labeling/prompts/current.md \
+     backend/local/eval_results/$RUN/candidate_prompt.md
+
+python -m backend.labeling.eval.eval_human_corrections \
+    --source db --mode verify --run-id $RUN
+
+# Deploy only after reviewing accuracy_report.md
+python -m backend.labeling.eval.eval_human_corrections \
+    --mode deploy --run-id $RUN
+```
+
+---
+
+## Reading the accuracy report
+
+`accuracy_report.md` in the run directory. Key dimensions:
+
+| Dimension | What it means |
+|-----------|--------------|
+| Category exact | `usage_category` matches human correction |
+| Name exact / partial | exact or ≥50% word overlap |
+| Owner confirmed | `protocol_likely=True` when human confirmed owner |
+| No-owner confirmed | `protocol_likely=False` when human confirmed no owner |
+| Wins / Regressions | wrong→right / right→wrong vs original prompt |
+| Confusion matrix | remaining wrong predictions: gt → predicted |
+| Confidence tiers | category accuracy split high/mid/low |
+
+**The 0% original baseline is expected** — rows are selected precisely because the AI was wrong on them.
+
+**No regressions = safe to deploy.** Any regression (right→wrong) needs investigation before deploying.
+
+---
+
+## Debugging common failures
+
+### Phase 1 produces no proposals
+- Check `per_row.jsonl` exists and is non-empty
+- Check `contract_label_review` has rows with human corrections (`human_usage_category`, `human_contract_name`, `gtp_no_owner_project`, etc.)
+- Inspect rows: `python3 -c "import json; [print(json.dumps(r, indent=2)) for r in [json.loads(l) for l in open('backend/local/eval_results/<run-id>/per_row.jsonl')][:2]]"`
+
+### Phase 2 returns unchanged prompt
+- Proposals didn't meet thresholds: `confidence >= 0.6 AND count >= 2` OR `confidence >= 0.85`
+- Check `candidate_prompt_changelog.md` for `skip_reason`
+- Low proposal count = not enough ground-truth rows; need more human corrections in Airtable
+
+### Phase 3 keeps re-fetching (slow)
+- Cache miss on every contract → check `backend/local/eval_cache/` exists and has `.json` files
+- Cache is populated on first run; subsequent runs are fast
+- Force refresh: `--refresh` flag on `context_cache.py` CLI
+
+### Owner accuracy shows 0% for new prompt
+- Means `ai_owner_project_likely` wasn't computed — only happens with old `verify_per_row.jsonl` files
+- Re-run Phase 3; `reclassify_row` now calls `_is_protocol_likely()` and attaches the field
+
+### `UndefinedTable` error during eval
+- `upsert_table` called with `public.<table>` prefix — pangres double-qualifies it
+- Pass bare table name only (no `public.` prefix)
+
+### Chain median DAA logged once per contract (slow DB)
+- Fixed via `_chain_median_cache` in `automated_labeler.py` — per-process cache
+- If still seeing repeated logs, check that `automated_labeler` module wasn't reloaded mid-run
+
+---
+
+## Key files
+
+| File | Role |
+|------|------|
+| `eval_human_corrections.py` | Orchestrator — all phases + deploy |
+| `prompt_synthesizer.py` | Phase 2 — aggregate proposals → Pro call → write candidate |
+| `re_eval_prompt.py` | Meta-eval + synthesis prompt schemas (Pro model instructions) |
+| `context_cache.py` | Phase 3 enrichment cache (Blockscout/Tenderly/GitHub) |
+| `backend/labeling/prompts/versions.json` | Prompt version history with accuracy per version |
+| `backend/labeling/prompts/current.md` | Live prompt (matches `_SYSTEM_INSTRUCTION`) |
+
+## Key DB tables
+
+| Table | What's in it |
+|-------|-------------|
+| `contract_label_features` | AI signals + classification per contract (Phase 1 source) |
+| `contract_label_review` | Human corrections audit log (ground-truth source) |
+
+---
+
+## Prompt versioning
+
+```
+backend/labeling/prompts/
+├── versions.json   ← {current: "v2", history: [{version, run_id, deployed_at, accuracy}]}
+├── current.md      ← copy of live _SYSTEM_INSTRUCTION
+├── v1.md
+└── v2.md
+```
+
+Deploy auto-increments version, writes `vN.md`, updates `current.md` and `versions.json`.
+To roll back: copy `vN.md` into `_SYSTEM_INSTRUCTION` in `ai_classifier.py` manually and update `versions.json`.
+
+---
+
+## Ground-truth filter
+
+A row is evaluated only when `contract_label_review` has at least one of:
+`human_contract_name`, `human_usage_category`, `gtp_owner_project_confirmed=True`, `gtp_no_owner_project=True`, `human_comment`
+
+More human corrections in Airtable → better eval signal.

--- a/.claude/skills/oli-attestation-flow.md
+++ b/.claude/skills/oli-attestation-flow.md
@@ -1,0 +1,111 @@
+---
+name: oli-attestation-flow
+description: Use when working on OLI attestation — what gets submitted, confidence thresholds, owner_project handling, protocol-contract-likely sentinel, gtp_no_owner_project flag, the reattest loop, or DAG task wiring for oli_airtable.py.
+---
+
+# OLI Attestation Flow
+
+## Two attestation paths
+
+```
+Automated labeler  →  'Label Pool Automated'  →  airtable_automated_attest  →  OLI
+External attester  →  'Label Pool Reattest'   →  airtable_reattest_attest   →  OLI
+```
+
+These are separate DAG tasks in `oli_airtable.py`. They read from different tables and must never be pointed at the same table.
+
+## What gets attested (automated path)
+
+```
+oli_automated_labeler.py  →  confidence >= 0.3  →  oli.submit_label_bulk()
+                                                     (direct, bypasses Airtable review)
+
+oli_airtable.py:airtable_automated_attest  →  human approves row in 'Label Pool Automated'
+                                            →  human overrides applied (coalesce)
+                                            →  oli.submit_label() per row
+                                            →  db_connector.insert_contract_label_review() (diff log)
+                                            →  row deleted from Airtable
+```
+
+The automated labeler attests low-confidence rows directly; the re-attest flow is for human-reviewed corrections.
+
+## OLI tags payload
+
+```python
+tags = {
+    'contract_name': ...,
+    'usage_category': ...,
+    'owner_project': ...,   # omitted if gtp_no_owner_project=True or sentinel
+}
+```
+
+`chain_id` comes from `ORIGIN_KEY_TO_CHAIN_ID` (derived from `main_config.py` — never hardcode).
+
+## `owner_project` rules
+
+| State | What happens |
+|-------|-------------|
+| Real OLI slug | Included in tags payload |
+| `protocol-contract-likely` | **Dropped** — sentinel, not a valid slug. Row surfaces for human review. |
+| `gtp_no_owner_project=True` | `owner_project` key omitted from OLI payload entirely |
+| `temp_owner_project` set | Stored in `contract_label_review` only — never attested |
+
+`read_all_label_pool_automated` handles the sentinel drop automatically. Verify it at call sites if bypassing the reader.
+
+## `protocol-contract-likely` sentinel lifecycle
+
+```
+_is_protocol_likely() returns True
+        ↓
+owner_project = 'protocol-contract-likely' written to Airtable 'Label Pool Automated'
+        ↓
+airtable_write_protocol_likely_to_automated() (oli_airtable.py:329) surfaces it for human review
+        ↓
+Human sets owner_project / temp_owner_project / gtp_no_owner_project
+        ↓
+read_all_label_pool_automated() drops sentinel → airtable_automated_attest() attests with real slug
+```
+
+Never let the sentinel reach `oli.submit_label()` — the OLI schema will reject it.
+
+## `contract_label_review` — append-only diff log
+
+Written by `airtable_automated_attest` at attest time. Records the delta between AI output and human-approved value:
+
+```python
+{
+    'address', 'origin_key',
+    'ai_contract_name',   # original classifier output
+    'ai_usage_category',
+    'gtp_contract_name',  # set only if human changed the AI value
+    'gtp_usage_category',
+    'gtp_owner_project_confirmed', 'gtp_no_owner_project',
+    'human_comment', 'temp_owner_project',
+}
+```
+
+`gtp_*` fields are `None` when the human accepted the AI value unchanged.
+
+**This table is the ground-truth source for the eval loop (Phase 1 critique).**
+
+## DAG schedule (`oli_airtable.py`)
+
+```
+schedule='50 00 * * *'  # 0:50am
+# After: coingecko, oli_oss_directory, oli_misc_sync
+# Before: metrics_sql_blockspace
+```
+
+## Confidence threshold
+
+Default `0.3` in `automated_labeler.py`. Configurable via `--confidence-threshold` CLI arg. Rows below threshold are written to Airtable but NOT submitted to OLI by the automated labeler. The human-review path (`oli_airtable.py`) has no confidence gate — human approval is the gate.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `protocol-contract-likely` appears in OLI | Sentinel not dropped before submit | Check `read_all_label_pool_automated` is used, not raw Airtable read |
+| Duplicate attestations on OLI | Row not deleted from Airtable after first attest | Verify delete step in `airtable_automated_attest` ran; check for Airtable API errors |
+| `owner_project` recID in OLI payload | Linked-record not resolved before submit | Run `resolve_recid_to_slug` before building tags |
+| `contract_label_review` missing rows | `contract_label_features` write failed → fallback to Airtable AI columns | Weaker diff signal; re-backfill `contract_label_features` to recover |
+| Row stuck in Airtable, never attested | `approve` column not set to True | Human must check 'approve' checkbox in Airtable |

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ backend/test_screenshots.py
 
 backend/src/adapters/*.txt
 claude_output.json
+
+handoff.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,18 @@
 # gtp-backend — Claude Code conventions
 
+## Skills index
+
+Detailed reference guides live in `.claude/skills/`. Load them when debugging the relevant subsystem.
+
+| Skill | When to use |
+|-------|-------------|
+| `classifier-eval-loop.md` | Running or debugging the eval pipeline (critique/synthesize/verify/deploy) |
+| `automated-labeler-pipeline.md` | Contracts missing, skipped, not enriched, not attested |
+| `airtable-labeling-patterns.md` | Linked-record resolution, human override coalesce, dedup, sentinel handling |
+| `oli-attestation-flow.md` | OLI submission rules, owner_project handling, reattest loop |
+
+---
+
 ## General rule — check for existing mappings first
 
 Before adding any new constant, dict, lookup table, or mapping anywhere in the codebase:
@@ -81,7 +94,20 @@ All chain mappings live in `backend/src/main_config.py` (`get_main_config`, `get
 - Classifier: `backend/labeling/ai_classifier.py`, model `gemini-2.5-flash`, temp 0.1.
 - Response schema **must** include `property_ordering=["reasoning","contract_name","usage_category","confidence"]`. Without this Flash generates `usage_category` before `reasoning` and hedges to "other".
 - All signal keys from `classify_contract()` return dict feed into `contract_label_features` — do not remove keys from the return dict without updating `_build_feature_row()` in `automated_labeler.py`.
-- Eval loop: `backend/labeling/eval/eval_human_corrections.py` — run against human-corrected rows before and after prompt changes to measure improvement.
+- `_is_protocol_likely()` in `automated_labeler.py` computes `ai_owner_project_likely` post-classification. `dex` is intentionally excluded from the fast-pass category list — unverified dex contracts are often private strategies. `novel_tokens` check runs after trading/other exclusion, not before.
+- Eval loop: `backend/labeling/eval/` — 4-phase pipeline (critique → synthesize → verify → deploy). See `.claude/skills/classifier-eval-loop.md` for full reference.
+
+## Prompt versioning
+
+- Live `_SYSTEM_INSTRUCTION` is tracked in `backend/labeling/prompts/current.md`.
+- Every deployed version is archived as `backend/labeling/prompts/vN.md` with accuracy metadata in `versions.json`.
+- Deploy via `--mode deploy` in the eval orchestrator — never edit `_SYSTEM_INSTRUCTION` directly without updating `current.md` and `versions.json`.
+- To roll back: copy `vN.md` into `_SYSTEM_INSTRUCTION` in `ai_classifier.py` and update `versions.json` manually.
+
+## Chain median DAA caching
+
+- `fetch_chain_median_daa()` in `automated_labeler.py` uses a module-level `_chain_median_cache` dict.
+- One DB connection per chain per process, not per contract. Do not call `DbConnector()` inside per-contract loops — use this cache pattern.
 
 ## Automated labeler — pipeline & debugging map
 

--- a/backend/labeling/ai_classifier.py
+++ b/backend/labeling/ai_classifier.py
@@ -344,7 +344,11 @@ def _get_gemini_client() -> "genai.Client":
 
 # ─── Static system instruction (sent once, not repeated per contract) ─────────
 
-_SYSTEM_INSTRUCTION = """You are a smart contract protocol analyst. Classify the contract described below by following the decision paths IN ORDER. Stop at the first path that applies.
+_SYSTEM_INSTRUCTION = """
+You are a smart contract protocol analyst. Classify the contract described below by following the decision paths IN ORDER. Stop at the first path that applies.
+
+## is_protocol_contract_likely
+Set to `true` ONLY when there is strong evidence of ownership or public infrastructure: `github.has_valid_repo=true`, a verified name from a known protocol, or high public usage (HIGH-DAA). Do NOT set to `true` for unverified, private-caller contracts based solely on token interactions (`novel_tokens`). Contracts classified as `trading` under PATH G1 or G2 MUST have `protocol_likely=false`, as they are private bots by definition.
 
 ## HOW TO CLASSIFY
 
@@ -368,6 +372,9 @@ that the few callers are real public EOAs (not admin keepers cycling addresses).
 
 ## DECISION PATHS (follow in order, stop at first match)
 
+### PATH -1 — Zero-Transaction Gate
+IF `txcount` = 0: This contract has never executed. All trace and log signals will be empty. Classify as `other` with name `UnexecutedContract` and low confidence. Stop here.
+
 ### PATH 0 — Identity Gate  (RUN FIRST, ALWAYS)
 Before evaluating any other path, evaluate identity:
 
@@ -380,9 +387,7 @@ Before evaluating any other path, evaluate identity:
       management (CLPool/CLGauge/NonfungiblePositionManager mint/burn/collect) ARE `trading`,
       even with confirmed identity. This single exception applies — no other identity-confirmed
       contract may be classified `trading` based on caller diversity alone.
-    → When `github.has_valid_repo=true`, the linked repository's organization or contract name
-      pattern (e.g. `TransitSwapRouterV5` → transit-finance, `keystone-*` → keystonehq) is a
-      strong owner-project signal. Use it to assert protocol_likely=true.
+    → When `github.has_valid_repo=true`, the linked repository's organization is a strong owner-project signal. You MUST use this to assert `protocol_likely=true` and name the owner project in your reasoning. The repository's identity is a primary classification signal; if the repo name implies a function (e.g., 'ultron-bridge'), use that to determine the category, overriding weaker trace signals.
 
   IF source_verified=False AND github.has_valid_repo=False:
     → No confirmed identity. PATH G1 / G2 / G3 caller-based trading defaults apply normally.
@@ -391,7 +396,9 @@ Before evaluating any other path, evaluate identity:
 IF source_verified=True AND blockscout_name != "unknown":
   → contract_name = exact Blockscout name
   → Classify by the semantic meaning of the verified name. Read it as a human — you know what protocols do.
-  → Use traces to disambiguate when the name alone is genuinely unclear. VRF calls (Chainlink VRF, Pyth) → gaming. NFT interactions without marketplace → gaming or non_fungible_tokens.
+  → Sanity Check: If the name implies a function (e.g., 'Bridge') but all corresponding trace/log signals are negative (`log_has_bridge_events=false`), the name may be misleading; re-evaluate based on other signals.
+  → Use traces to disambiguate when the name alone is genuinely unclear. VRF calls (Chainlink VRF, Pyth) → gaming. NFT interactions without marketplace → gaming or non_fungible_tokens. If `traces_only_raw_opcodes=true`, state that the trace is uninformative; do not invent function calls.
+  → When trace signals are absent because `all_traces_empty=true`, the semantic meaning of the verified name is the sole, authoritative signal. Trust it completely.
   → The verified name overrides MEV/bot heuristics — do NOT reclassify a named protocol as trading because callers are private or success_rate is low.
   → Protocol-specific corrections (the name sounds like X but IS actually Y):
       Permit2, Permit3, AllowanceHolder → developer_tools  (approval middleware, not a DEX router)
@@ -401,7 +408,7 @@ IF source_verified=True AND blockscout_name != "unknown":
       *DVN, *Dvn → cc_communication  (LayerZero verifier network)
       MayanSwift*, Mayan*Bridge → bridge
       Socket*, SocketGateway, SocketBridge → bridge
-      OffchainAggregator, AccessControlledOffchainAggregator, *EACAggregator* → oracle  (Chainlink data feed)
+      OffchainAggregator, AccessControlledOffchainAggregator, *EACAggregator*, BlockhashStore → oracle  (Chainlink data feed or utility)
       OpenOceanSwapModule, OpenOcean*Module → nft_marketplace  (Seaport-bound; classify by host protocol)
       ConditionalTokens, CTFExchange, NegRiskAdapter → prediction_markets  (Polymarket / Omen pattern)
       IdRegistry, NameRegistry, *Registrar (Farcaster, ENS, Lens) → identity
@@ -409,13 +416,16 @@ IF source_verified=True AND blockscout_name != "unknown":
         (the factory's role is deployment infra; do not inherit category from what it deploys)
       TransparentUpgradeableProxy, ERC1967Proxy, ProxyAdmin (when bs_name is exactly that) → developer_tools
       *Router without clear DEX context → examine trace, do NOT default to dex
+      *FeeForwarder, *FeeProvider, *FeeCollector, *FeeDistributor → payments
+      BatchResolver → gaming
+  → Airdrop/Distribution patterns: If the name contains keywords like Airdrop, Claim, Distributor, Vesting, Launcher, Rewards, or Points, classify as `airdrop`. This pattern overrides a simple token-name match.
   → Stablecoin token check (W6): if the contract name is a distribution/claim mechanism
     (Claim, DiamondClaim, Distributor, Airdrop, Vesting) AND traces show transfers of known
     stablecoin tokens (Tether, TetherToken, USDT, USDC, FiatToken, DAI, BUSD, TUSD, or any
     token name containing "USD" or "Stablecoin") → stablecoin, NOT fungible_tokens.
 
 ### PATH B — Proxy Delegating to Named Implementation
-IF "this contract itself delegates to (named)" != "none":
+IF the signal "this contract itself delegates to (named)" is non-null and contains a resolved contract name:
   → This proxy IS that named implementation. Classify by what the delegate target does.
   → CLPool / UniswapV3Pool / PancakeV3Pool → dex
   → EntryPoint → erc4337
@@ -484,12 +494,14 @@ IF "Oracle function calls detected" list is non-empty AND those functions are ce
 
 ### PATH G1 — Private Callers (PRIVATE diversity ≤20%)
 IF caller_diversity_label = "PRIVATE" AND no prior path matched:
+  **STOP: First, check `source_verified` and `github.has_valid_repo`. If either is true, you MUST follow the 'EXCEPTION' logic below. Do not proceed to the 'Unverified private callers' section.**
   **CRITICAL: This path applies even when traces are raw opcodes only and identity is unknown.
   Raw-opcode traces + PRIVATE callers + no identity IS the trading bot signature — intentionally unverified.
   Do NOT skip to G0 because traces are unreadable. If the label says PRIVATE, use G1.**
   EXCEPTION — verified contracts OR `github.has_valid_repo=true`: do NOT apply trading defaults.
     Contracts with confirmed identity (verified source OR linked GitHub repo) and private callers
     are almost always protocol infrastructure (vault, liquidator, position manager), not MEV bots.
+    For example, a contract interacting with another contract named 'Rewards' or distributing a protocol's own token is likely `staking` or `airdrop` infrastructure, not `trading`.
     Classify by trace content; only assign trading if traces explicitly show MEV patterns (raw slot0
     reads across many pools, failed-tx-heavy swaps).
   EXCEPTION-TO-EXCEPTION: verified or github-linked contracts that interact directly with
@@ -502,9 +514,11 @@ IF caller_diversity_label = "PRIVATE" AND no prior path matched:
     clear failed-tx patterns → trading still possible.
   VERIFIED + bridge calls: prefer bridge or cc_communication.
   → Unverified private callers: TRADING IS THE ONLY VALID CLASSIFICATION. Do not use other.
+    EXCEPTION for low activity: If txcount < 5 AND avg_daa < 1, this is likely a test or deployment artifact, not an active bot. Classify as `other` with the name `LowActivityContract` and stop.
     A single operator running automated on-chain transactions is by definition a trading bot.
     Unverified bots intentionally leave no decoded traces — raw opcodes and no identity ARE the signal.
     "No specific trading signals" is not a valid reason to pick other over trading here.
+    These contracts MUST have `is_protocol_contract_likely=false`.
     Name it based on available signals, but the category is always trading:
   - LP/gauge contracts (CLGauge, CLPool, NonfungiblePositionManager) + novel tokens in traces:
       ACTIVE REBALANCER (slot0 reads + _collect + burns/mints in same tx) → trading, "[Protocol]CLRebalancer"
@@ -520,6 +534,7 @@ IF caller_diversity_label = "PRIVATE" AND no prior path matched:
 IF caller_diversity_label = "KEEPER" AND no prior path matched:
   EXCEPTION — verified contracts with named protocol interactions: classify by trace content.
     Verified keeper contracts are typically protocol infrastructure (liquidators, settlement, distributors).
+    If a verified contract is a proxy delegating to an unverified implementation (raw_delegate=true) and its traces consist only of raw opcodes, its function is ambiguous. Classify as `other` and name it `VerifiedProxyToUnknownImpl`.
   EXCEPTION-TO-EXCEPTION: verified contracts whose dominant trace activity is automated LP
     management (CLPool/CLGauge/NonfungiblePositionManager mint/burn/collect) ARE trading.
   VERIFIED + DEX router calls: KEEPER + verified + DEX router = DEX settlement/aggregation signature
@@ -527,16 +542,16 @@ IF caller_diversity_label = "KEEPER" AND no prior path matched:
   VERIFIED + bridge calls: prefer bridge or cc_communication.
   → Unverified multi-operator permissioned system. Check explicit protocol signals FIRST before
     defaulting to trading. Apply these overrides in order even when unverified:
-  1. "Direct calls into lending protocols" non-empty (Aave, Compound, Morpho, etc.)
+  1. Interactions with known DEX infrastructure (`named_contracts_in_traces` contains SwapRouter, UniswapV3Pool) → dex.
+  2. "Direct calls into lending protocols" non-empty (Aave, Compound, Morpho, etc.)
      AND no slot0/price-read pattern → lending (or derivative for perp protocols)
      Name: "[Protocol]Liquidator" or "[Protocol]KeeperBot"
-  2. "Direct calls into bridge protocols" non-empty (Stargate, LayerZero, Connext, etc.)
+  3. "Direct calls into bridge protocols" non-empty (Stargate, LayerZero, Connext, etc.)
      OR bridge events (MessagePassed, SentMessage, PacketSent) → bridge or cc_communication
-  3. ERC-4337 events (UserOperationEvent, AccountDeployed) → erc4337
-  4. Governance events (ProposalCreated, VoteCast) → governance
+  4. ERC-4337 events (UserOperationEvent, AccountDeployed) → erc4337
+  5. Governance events (ProposalCreated, VoteCast) → governance
   → After checking the above, if no protocol signal matched:
-  **Raw opcodes only + no identity + KEEPER callers → trading, "StrategyExecutor". Do NOT use other.**
-  Multiple operators running opaque automated strategies is a trading pattern, not "ambiguous".
+  If traces are raw opcodes only with no identity and KEEPER callers, the contract's function is ambiguous. If there are absolutely no other DeFi signals (swaps, lending, LP management), classify as `other` with name `AmbiguousExecutor`. If DeFi signals are present but un-decoded, `trading` with name `StrategyExecutor` is a reasonable fallback.
   - LP/gauge contracts + novel tokens: same ACTIVE/PASSIVE rebalancer distinction as G1
   - AccessControl events + no identifiable protocol interactions → trading executor
   - Known non-trading protocol interactions in traces: classify by what it interacts with
@@ -548,7 +563,7 @@ IF caller_diversity_label = "PUBLIC" AND no prior path matched:
   → Many different callers — public-facing. Classify by what the contract does.
   - **Stablecoin name match**: novel_tokens or bs_token_transfers token name/symbol contains
     USD / Stable / DAI / USDT / USDC / USDM / BUSD / TUSD / FRAX / LUSD AND that token is the
-    primary asset moved → stablecoin. Token-name pattern wins as primary signal here.
+    primary asset moved. This is a strong signal, but must be confirmed by contract function. Classify as `stablecoin` only when the contract's primary role is distribution (Airdrop, Vesting), minting, or redemption of the stablecoin itself. If traces suggest yield, lending, or staking activity, prefer that category.
   - **Low success_rate override**: success_rate < 60% with DEX router or pool-swap traces →
     public arbitrage / sandwich pattern → trading, "MEVBot" or "ArbitrageBot". Many public callers
     competing and failing is the MEV signature; do NOT classify as dex when most txs revert.
@@ -569,6 +584,8 @@ IF caller_diversity_label = "PUBLIC" AND no prior path matched:
   - IMPORTANT: Named contracts in the DEEP trace are downstream callees — do NOT classify this contract as CLPool just because CLPool appears in the trace.
 
 ### avg_daa Discriminator — Trading vs DEXAggregator
+CRITICAL: These DAA gates are mandatory checks that MUST be performed before assigning the `dex` category to any unverified contract in PATH C, D, or G. Your reasoning must explicitly state which DAA tier the contract falls into.
+
 The single strongest signal separating private trading bots from public DEX infrastructure is
 **absolute avg_daa relative to chain_median_daa**. Apply these gates BEFORE picking dex/DEXAggregator:
 
@@ -577,14 +594,12 @@ The single strongest signal separating private trading bots from public DEX infr
        of how trading-shaped the traces look. Even if the contract calls DEX routers and swaps
        look bot-like, high public usage rules out trading. Classify dex / bridge / oracle / etc.
        by trace content. Override "trading bot" heuristics from G1/G2.
+    → Note: 'Public infrastructure' does not automatically mean `protocol_likely=true`. Only assert `protocol_likely=true` if there are positive ownership signals like a verified name or a linked GitHub repo.
 
   LOW-DAA (avg_daa < max(chain_median_daa × 0.05, 3)):
-    → Private operator(s). Cannot be DEXAggregator regardless of trace shape. A real DEX
-       aggregator must have a public user base.
+    → Private operator(s). DEXAggregator is invalid at this DAA level unless there is strong evidence the contract is a component of a known public aggregator. A contract that only performs price reads (slot0, getReserves) should be classified as `trading` (PriceScanner) by default.
     → If success_rate < 90% AND DEX/swap activity → trading (MEVBot / ArbitrageBot).
     → If success_rate ≥ 90% AND DEX/swap activity → trading (StrategyExecutor / [Protocol]Rebalancer).
-    → "DEXAggregator" is INVALID at this DAA level unless caller_diversity_label is reliably
-       PUBLIC and you can confirm the callers are real EOAs (not admin/keeper EOAs cycling addresses).
 
   MID-DAA (between LOW and HIGH thresholds):
     → Examine caller_diversity_label and success_rate.
@@ -600,13 +615,16 @@ IF caller_diversity_label = "UNKNOWN":
   **ONLY use this path if the data literally says "Caller diversity label: UNKNOWN". If it says PRIVATE, KEEPER, or PUBLIC — use G1, G2, or G3 instead, regardless of trace quality.**
   UNKNOWN means caller sampling failed — a data gap. Without caller data, use available signals carefully.
   → Decision tree:
-  1. Non-trading events (bridge, NFT transfers, governance, staking) → classify by those signals
-  2. success_rate clearly < 30% → near-certain MEV → trading, "MEVBot"
-  3. Named protocol interactions in traces that imply a specific non-trading purpose → classify accordingly
-  4. txcount > 300k AND all_trace_call_graphs_empty=True AND no events AND no meaningful identity
+  1. IF `github.has_valid_repo=true`: This contract has confirmed identity but no on-chain activity was observed. Classify as `developer_tools` with the name `UnusedProtocolComponent`.
+  2. Non-trading events (bridge, NFT transfers, governance, staking) → classify by those signals
+  3. success_rate clearly < 30% → near-certain MEV → trading, "MEVBot"
+  4. Named protocol interactions in traces that imply a specific non-trading purpose → classify accordingly
+  5. txcount > 300k AND all_trace_call_graphs_empty=True AND no events AND no meaningful identity
      → high-volume unidentifiable contract; lean trading, "StrategyExecutor"
      BUT: if DAA/tx signal says BROAD USER BASE (>5%) → override to other (public-facing, not a bot)
-  5. All else → other, "AmbiguousContract"
+  6. IF all_traces_empty=True AND novel_tokens contains multiple memecoin-like names → trading, "SniperBot".
+  7. IF all_traces_empty=True AND novel_tokens or bs_token_transfers contains a pair of common DeFi tokens (e.g., WETH, USDC) → lean trading, name based on the pair, e.g., "WETH-USDC-LPManager".
+  8. All else → other, "AmbiguousContract"
   Note: DAA/tx=0.00% often means missing data, not confirmed automation — do not treat as strong trading signal alone.
 
 ---
@@ -615,32 +633,27 @@ IF caller_diversity_label = "UNKNOWN":
 Name what the contract IS or DOES — use protocol-aware names when traces reveal them.
 
 Naming source priority (high to low):
-1. Verified Blockscout name (PATH A) or delegate-target name (PATH B).
-2. Named contracts in traces — `named_contracts_in_traces` is the strongest external-identity signal.
-   Build descriptive names from these: "[Protocol]Manager", "[Protocol]Rebalancer", "[Protocol]Adapter".
-   For LP managers, prefer the underlying-asset name over the AMM venue when a major asset (USDC/USDT/DAI/FiatToken) is present:
-   "FiatTokenPositionManager" beats "AerodromeCLRebalancer" if the position is USDC-denominated.
-3. Novel-protocol tokens (`novel_tokens` list) — only when traces lack named protocol contracts.
-4. Behavioral name from caller pattern — "MEVBot", "ArbitrageBot", "PriceScanner", "StrategyExecutor".
+1. Specific naming patterns from the matched DECISION PATH (e.g., '[Protocol]CLRebalancer' from PATH G1) override all other naming sources. You MUST use these when their criteria are met.
+2. Verified Blockscout name (PATH A) or delegate-target name (PATH B).
+3. Protocol name from `github.has_valid_repo=true`. Use it as a prefix, e.g., '[Protocol]Escrow'.
+4. Named contracts in traces — `named_contracts_in_traces` is the strongest external-identity signal. Build descriptive names from these: "[Protocol]Manager", "[Protocol]Adapter".
+   Exception for LP Rebalancers: If behavior is clearly LP management (slot0 reads, mint/burn/collect) AND a major stablecoin (USDC/USDT/DAI/FiatToken) is present, you MUST prioritize the stablecoin for naming (e.g., 'FiatTokenCLRebalancer').
+5. Novel-protocol tokens (`novel_tokens` list) — only when traces lack named protocol contracts. When multiple tokens are present, prioritize the non-stablecoin or protocol-specific token.
+6. Behavioral name from caller pattern or trace function calls — "MEVBot", "ArbitrageBot", "PriceScanner", "StrategyExecutor". If you see function names describing specific actions on an object (e.g., `equipItem`, `mintCharacter`), prefer a role-based name like `ItemManager` or `CharacterFactory`.
 
 Constraints:
-- Token transfers from Blockscout (`bs_token_transfers`) are weaker evidence than trace contract names.
-  Do NOT name a contract after a token in `bs_token_transfers` if `named_contracts_in_traces` is non-empty.
-- Forbid composites that fuse a token symbol with a trace-derived contract type. Examples:
-  "UAVPoolManager" (UAV from token + PoolManager from trace) is WRONG — pick one source.
-  Use "PoolManager" (trace identity) or, if the underlying asset is the dominant signal,
-  "[Asset]PositionManager". Never glue them.
-- Verified contract with a generic standard-implementation name (ERC20, ERC721, OptimismMintableERC20,
-  StandardToken): the verified name is uninformative — derive the real name from the token name in
-  bs_token_transfers (e.g. "Autonolas" not "OptimismMintableERC20").
-- Unverified trading contracts: describe the behavior — "MEVBot", "ArbitrageBot", "PriceScanner",
-  "[Protocol]CLRebalancer", "[Protocol][Token]LPManager".
-- Unverified non-trading: derive from trace interactions — "OracleConsumer", "DEXAggregator", "BridgeCaller".
-- PATH E (EIP-1167 clones, empty trace): name "CloneExecutor" by default — do not say "StrategyExecutor"
-  unless the caller pattern matches G1.
-- Use "AmbiguousContract" ONLY when bs_name=unknown AND novel_tokens=empty AND named_contracts_in_traces=empty AND log_signals all false.
-  Otherwise produce a descriptive name.
-- NEVER use generic filler: "UnverifiedProxy", "UnverifiedContract", "Unknown", "MinimalProxy".
+- **Hierarchy is strict**: Prioritize `named_contracts_in_traces` over `novel_tokens` or `bs_token_transfers`.
+- **Forbid composites**: Do not fuse signals from different priority levels. Examples:
+  "UAVPoolManager" (UAV from token + PoolManager from trace) is WRONG. Pick one source.
+  "BasedPepePriceScanner" (token + behavior) is WRONG. For unverified trading contracts, prioritize the behavioral name ('PriceScanner', 'StrategyExecutor') over a name derived from a novel token.
+  "SwapRouterStrategyExecutor" (traced contract + behavior) is WRONG. Derive a descriptive name like 'SwapRouterManager' instead.
+- **Private Trading Bots (PATH G1/G2)**: The behavioral name ('StrategyExecutor', 'MEVBot') is the primary identity. Do NOT prepend token names. The presence of novel tokens indicates assets being traded, not the bot's identity.
+- **Generic Names**: If a verified name is a generic implementation (ERC20, ERC721, ERC1967Proxy, StandardToken), it is uninformative. Derive the real name from the token in `bs_token_transfers` (e.g. "Autonolas" not "OptimismMintableERC20").
+- **Unverified trading contracts**: Describe the behavior — "MEVBot", "ArbitrageBot", "PriceScanner". Only use specific names like 'PriceScanner' or 'MEVBot' when strict criteria (PATH F, low success_rate) are met. Otherwise, default to "StrategyExecutor". The names '[Protocol]CLRebalancer' and '[Protocol][Token]LPManager' MUST only be used with explicit trace evidence of LP/gauge interaction.
+- **Unverified non-trading**: derive from trace interactions — "OracleConsumer", "DEXAggregator", "BridgeCaller".
+- **PATH E (EIP-1167 clones, empty trace)**: name "CloneExecutor" by default — do not say "StrategyExecutor" unless the caller pattern matches G1.
+- **Use "AmbiguousContract"** ONLY when bs_name=unknown AND novel_tokens=empty AND named_contracts_in_traces=empty AND log_signals all false. Otherwise produce a descriptive name.
+- **NEVER use generic filler**: "UnverifiedProxy", "UnverifiedContract", "Unknown", "MinimalProxy".
 
 ---
 
@@ -652,7 +665,8 @@ Examples:
   "PATH G1: diversity=PRIVATE, success=99.9%, AccessControl, no swap events → trading. Ruled out dex (no pool calls)."
   "PATH C: router_calls=[SwapRouter02], DAA/tx=0.3%, success=18% → trading/MEVBot. Ruled out dex (above router stack)."
   "PATH A: verified=True, name=GridMining, VRF calls in trace → gaming. Ruled out other (name is specific)."
-No filler, no articles, fragments OK. Always name the path. Always name what was ruled out."""
+No filler, no articles, fragments OK. Always name the path. Always name what was ruled out.
+"""
 
 
 # ─── Classifier ───────────────────────────────────────────────────────────────
@@ -667,7 +681,6 @@ async def classify_contract(
     session: aiohttp.ClientSession,
     address_logs: list[dict] | None = None,
     token_transfers: list[dict] | None = None,
-    anthropic_client=None,  # kept for API compat, unused
 ) -> dict:
     """Classify a single contract using Gemini with function calling.
 

--- a/backend/labeling/automated_labeler.py
+++ b/backend/labeling/automated_labeler.py
@@ -228,14 +228,22 @@ def fetch_unlabeled_contracts(
     return records
 
 
+_chain_median_cache: dict[str, float] = {}
+
+
 def fetch_chain_median_daa(origin_keys: list[str], days: int = 7) -> dict[str, float]:
     """Query the DB for median avg_daa of top contracts (>=0.1% of chain txcount) per chain.
 
     Returns a dict mapping origin_key -> median_daa. Falls back to empty dict on error.
+    Results are cached in-process so repeated calls for the same chain skip the DB round-trip.
     """
+    uncached = [k for k in origin_keys if k not in _chain_median_cache]
+    if not uncached:
+        return {k: _chain_median_cache[k] for k in origin_keys if k in _chain_median_cache}
+
     try:
         db = DbConnector()
-        keys_str = "','".join(origin_keys)
+        keys_str = "','".join(uncached)
         sql = f"""
             WITH chain_totals AS (
                 SELECT origin_key, SUM(txcount) AS total_txcount
@@ -264,12 +272,17 @@ def fetch_chain_median_daa(origin_keys: list[str], days: int = 7) -> dict[str, f
         """
         import pandas as pd
         df = pd.read_sql(sql, db.engine)
-        result = dict(zip(df['origin_key'], df['median_daa'].astype(float)))
-        logger.info(f"Chain median DAA: { {k: f'{v:.1f}' for k, v in result.items()} }")
-        return result
+        fetched = dict(zip(df['origin_key'], df['median_daa'].astype(float)))
+        _chain_median_cache.update(fetched)
+        cached_hits = [k for k in origin_keys if k not in uncached]
+        logger.info(
+            f"Chain median DAA fetched={{{', '.join(f'{k}:{v:.1f}' for k, v in fetched.items())}}} "
+            f"cached_hits={cached_hits}"
+        )
+        return {k: _chain_median_cache[k] for k in origin_keys if k in _chain_median_cache}
     except Exception as e:
         logger.warning(f"Could not fetch chain median DAA from DB (falling back to 0): {e}")
-        return {}
+        return {k: _chain_median_cache[k] for k in origin_keys if k in _chain_median_cache}
 
 
 def inject_chain_median_daa(contracts: list[dict], days: int = 7) -> None:
@@ -552,15 +565,8 @@ def _is_protocol_likely(label: dict, blockscout: dict, log_signals: dict, metric
     category = label.get('usage_category', '')
     confidence = label.get('confidence', 0.0)
     success_rate = metrics.get('success_rate')
-    # Treat None success_rate as non-bot (don't penalise missing data)
     if success_rate is None:
         success_rate = 1.0
-
-    # Novel protocol tokens in every tx override trading exclusion.
-    # A contract that interacts with specific protocol tokens on ≥50% of traces
-    # is protocol-specific infrastructure even when classified as trading.
-    if label.get('novel_tokens'):
-        return True
 
     # Hard exclusions (only applies when NOT verified)
     if category in ('trading', 'other'):
@@ -570,11 +576,17 @@ def _is_protocol_likely(label: dict, blockscout: dict, log_signals: dict, metric
     if success_rate < 0.40:
         return False
 
-    # Fast-pass: categories that are always public protocol contracts.
-    # bridge/lending/erc4337 come from pre-computed callee matches (W4 fix).
-    # dex/stablecoin/oracle are confirmed protocol-only from human review data.
+    # Novel protocol tokens in non-trading, non-other contracts signal specific protocol identity.
+    # Gated after trading/other exclusion — a bot trading known tokens is still a bot.
+    if label.get('novel_tokens'):
+        return True
+
+    # Fast-pass: categories with strong public-infrastructure priors.
+    # bridge/lending/erc4337/cc_communication/derivative are confirmed by pre-computed callee matches.
+    # stablecoin/oracle are protocol-only from human review data.
+    # dex excluded: unverified dex-classified contracts can be private strategies with public callers.
     if category in ('bridge', 'lending', 'erc4337', 'cc_communication', 'derivative',
-                    'dex', 'stablecoin', 'oracle'):
+                    'stablecoin', 'oracle'):
         return True
 
     # Strong positive signals — one is sufficient

--- a/backend/labeling/eval/README.md
+++ b/backend/labeling/eval/README.md
@@ -1,74 +1,162 @@
-# Classifier Self-Critique Eval
+# Classifier Self-Critique Eval — RL-Inspired 3-Phase Pipeline
 
-Re-runs `ai_classifier.classify_contract()` on rows humans corrected, then asks
-`gemini-2.5-pro` (the meta-evaluator) to diagnose what went wrong and propose
-concrete edits to `_SYSTEM_INSTRUCTION`.
+Iteratively improves `_SYSTEM_INSTRUCTION` in `ai_classifier.py` by critiquing the classifier
+against human corrections, synthesizing a better prompt, and verifying the improvement.
+
+## How it works
+
+```
+Phase 1  CRITIQUE   DB only, no enrichment API    N × Pro calls   per_row.jsonl + report.md
+Phase 2  SYNTHESIZE 1 Pro call                    1 Pro call      candidate_prompt.md
+Phase 3  VERIFY     re-enrich + Flash             N × Flash       accuracy_report.md
+         DEPLOY     patch ai_classifier.py        0 API calls     prompts/vN.md + versions.json
+```
+
+`contract_label_features` stores all decoded signals the meta-critique needs.
+Critiquing stored AI output first (zero enrichment cost) produces ranked proposals.
+Only after a candidate prompt exists does Phase 3 spend Blockscout/Tenderly/Flash credits.
 
 ## Files
 
-- `context_cache.py` — caches on-chain context (Blockscout/Tenderly/GitHub) per `(address, origin_key)` so prompt iterations don't re-spend API credits. Cache lives at `backend/local/eval_cache/`.
-- `re_eval_prompt.py` — meta-evaluator system prompt + JSON response schema.
-- `eval_human_corrections.py` — orchestrator. Loads dump, filters to rows with human corrections, reclassifies, meta-evals, persists JSONL + markdown report.
+| File | Role |
+|------|------|
+| `eval_human_corrections.py` | Orchestrator — all phases + deploy |
+| `prompt_synthesizer.py` | Phase 2 — aggregate proposals → call Pro → write candidate prompt |
+| `re_eval_prompt.py` | Meta-eval prompt + schema; synthesis prompt + schema |
+| `context_cache.py` | On-chain enrichment cache for Phase 3 (Blockscout/Tenderly/GitHub) |
+
+## Prompt versioning
+
+Deployed prompts live in `backend/labeling/prompts/`:
+
+```
+backend/labeling/prompts/
+├── versions.json    ← manifest: current pointer + history with accuracy per version
+├── current.md       ← copy of whatever is live in ai_classifier.py
+├── v1.md
+├── v2.md
+└── ...
+```
+
+`versions.json` entry per version:
+```json
+{
+  "version": "v2",
+  "run_id": "2026-05-26_v1",
+  "deployed_at": "2026-05-26T10:00:00Z",
+  "lines": 325,
+  "accuracy": {
+    "category_new": "18/31 (58.1%)",
+    "name_exact_new": "10/45 (22.2%)",
+    "wins_regressions": "Wins: 18 | Regressions: 1"
+  }
+}
+```
 
 ## Quickstart
 
-Smoke test (no meta calls, 3 rows):
+### Phase 1 — critique
 
 ```bash
-python backend/labeling/eval/eval_human_corrections.py \
-    --run-id smoke --limit 3 --skip-meta
+# Smoke test: 3 rows, no Pro calls
+python -m backend.labeling.eval.eval_human_corrections \
+    --source db --mode critique --run-id smoke --limit 3 --skip-meta
+
+# Full critique
+python -m backend.labeling.eval.eval_human_corrections \
+    --source db --mode critique --run-id $(date +%Y-%m-%d)_v1
 ```
 
-Full run on every row with a human correction:
+Outputs to `backend/local/eval_results/<run-id>/`:
+- `per_row.jsonl` — per-contract errors + proposals
+- `report.md` — ranked error patterns + prompt-edit proposals
+
+### Phase 2 — synthesize
 
 ```bash
-python backend/labeling/eval/eval_human_corrections.py \
-    --run-id 2026-04-27_pass1
+python -m backend.labeling.eval.eval_human_corrections \
+    --mode synthesize --run-id <run-id>
 ```
 
-Force-refresh on-chain context (skip cache):
+Outputs:
+- `candidate_prompt.md` — complete revised `_SYSTEM_INSTRUCTION`
+- `candidate_prompt_changelog.md` — what changed and why
+
+Review the diff before Phase 3:
+```bash
+diff backend/labeling/prompts/current.md \
+     backend/local/eval_results/<run-id>/candidate_prompt.md
+```
+
+### Phase 3 — verify
 
 ```bash
-python backend/labeling/eval/eval_human_corrections.py \
-    --run-id 2026-04-27_refresh --refresh
+python -m backend.labeling.eval.eval_human_corrections \
+    --source db --mode verify --run-id <run-id>
 ```
 
-Bulk-warm cache only:
+Output: `accuracy_report.md` — category/name/owner accuracy before vs after, confusion matrix,
+name partial credit (word overlap ≥50%), confidence calibration by tier.
+
+### Deploy
+
+Once satisfied with the accuracy report:
 
 ```bash
-python backend/labeling/eval/context_cache.py --limit 0
+python -m backend.labeling.eval.eval_human_corrections \
+    --mode deploy --run-id <run-id>
 ```
 
-## Outputs
+- Patches `_SYSTEM_INSTRUCTION` in `ai_classifier.py`
+- Writes `backend/labeling/prompts/vN.md`
+- Updates `current.md` and `versions.json`
+- No-ops if the prompt is already current
 
-- `backend/local/eval_results/<run_id>/per_row.jsonl` — one JSON object per evaluated row containing `{address, origin_key, ground_truth, ai_original, ai_rerun, raw_signals, meta_eval, ts}`.
-- `backend/local/eval_results/<run_id>/report.md` — aggregated patterns + ranked prompt-edit proposals + per-row diff table.
+### Full pipeline in one command
+
+```bash
+python -m backend.labeling.eval.eval_human_corrections \
+    --source db --mode full --run-id <run-id>
+```
+
+Runs Phases 1–3 sequentially. Deploy is a separate step by design — review
+`accuracy_report.md` before committing to a new version.
+
+## Accuracy report dimensions
+
+| Dimension | What it measures |
+|-----------|-----------------|
+| Category exact | `usage_category` matches human correction |
+| Name exact | `contract_name` case-insensitive exact match |
+| Name partial | ≥50% word overlap between predicted and human name |
+| Owner confirmed | `protocol_likely=True` when human confirmed an owner |
+| No-owner confirmed | `protocol_likely=False` when human confirmed no owner |
+| Confidence tiers | Category accuracy split by high/mid/low confidence |
+| Wins / Regressions | Rows flipped right→wrong and wrong→right vs original |
+| Confusion matrix | Ground truth → predicted for remaining wrong predictions |
 
 ## Ground-truth filter
 
-A row is evaluated only when at least one of these is set:
+A row is evaluated only when at least one of these is set in `contract_label_review`:
 
 - `human_contract_name`
-- `human_usage_category` (slug)
+- `human_usage_category`
 - `gtp_owner_project_confirmed=True` AND `owner_project_linked` non-empty
 - `gtp_no_owner_project=True`
-- `temp_owner_project` non-empty
 - `human_comment` non-empty
 
-## Future RL hook
+## Phase 2 proposal thresholds
 
-Per-row JSONL is shaped close to (state, action, reward) for offline RL:
-
-- **state** = `ground_truth` + `raw_signals`
-- **action** = `ai_rerun`
-- **reward signal** = `meta_eval.severity` + per-field correctness comparison
-
-Once `contract_label_review` is populated, swap the dump loader for a SQL
-query against `contract_label_review JOIN contract_label_features` — no other
-structural changes needed.
+Applied if: `confidence >= 0.6 AND count >= 2`
+OR: `confidence >= 0.85` (single high-confidence proposal).
+Conflicting proposals for the same section: highest confidence wins.
 
 ## Env required
 
-- `GEMINI_API_KEY` — used for both classifier (Flash) and meta-evaluator (Pro)
-- `BLOCKSCOUT_API_KEYS`, `TENDERLY_ACCESS_KEY`, GitHub token — only needed on cache miss
-- DB env vars (`DB_*`) — needed only on cache miss (for chain median DAA + metrics)
+- `GEMINI_API_KEY` — Pro for Phases 1–2, Flash for Phase 3
+- `DB_*` — all phases (`contract_label_features`, `contract_label_review`, chain median DAA)
+- `BLOCKSCOUT_API_KEYS`, `TENDERLY_ACCESS_KEY`, GitHub token — Phase 3 cache misses only
+
+## Further reference
+
+Debugging guide (phase failures, slow runs, owner scoring, common errors): `.claude/skills/classifier-eval-loop.md`

--- a/backend/labeling/eval/context_cache.py
+++ b/backend/labeling/eval/context_cache.py
@@ -46,9 +46,7 @@ from concurrent_contract_analyzer import (  # noqa: E402
 from automated_labeler import (  # noqa: E402
     enrich_contract,
     inject_chain_median_daa,
-    fetch_chain_median_daa,
     _load_chain_config,
-    ORIGIN_KEY_TO_CHAIN_ID,
 )
 
 logger = logging.getLogger("eval.cache")
@@ -121,10 +119,10 @@ def _fetch_db_metrics(address: str, origin_key: str, days: int = 7) -> Optional[
         return None
 
 
-def _seed_metrics_from_dump_row(row: dict, days: int = 7) -> dict:
-    """Fallback: build a plausible metrics dict from the validation-dump row when DB read fails."""
+def _seed_metrics_from_row(row: dict, days: int = 7) -> dict:
+    """Fallback: build a metrics dict from a DB row when the live DB fetch fails."""
     txcount = int(row.get("txcount") or 0)
-    gas_eth = 0.0  # not in dump
+    gas_eth = 0.0
     avg_daa = float(row.get("avg_daa") or 0)
     rel_cost = float(row.get("rel_cost") or 0)
     sr = row.get("success_rate")
@@ -181,7 +179,7 @@ async def build_or_load(
 
     # Cache miss — must run enrichment.
     metrics = _fetch_db_metrics(address, origin_key) or (
-        _seed_metrics_from_dump_row(dump_row) if dump_row else {}
+        _seed_metrics_from_row(dump_row) if dump_row else {}
     )
     contract = {"address": address, "origin_key": origin_key, "metrics": metrics}
 
@@ -254,22 +252,3 @@ async def warm_many(rows: list[dict], refresh: bool = False, concurrency: int = 
                 logger.error(f"warm failed for {r.get('address')}: {e}")
 
         await asyncio.gather(*(_one(r) for r in todo))
-
-
-# ── CLI ──────────────────────────────────────────────────────────────────────
-if __name__ == "__main__":
-    import argparse
-
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
-
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--dump", default=str(_BACKEND_DIR / "local/validation_dump_2026-04-25/all_109_combined.json"))
-    ap.add_argument("--refresh", action="store_true")
-    ap.add_argument("--limit", type=int, default=0)
-    ap.add_argument("--concurrency", type=int, default=3)
-    args = ap.parse_args()
-
-    rows = json.loads(Path(args.dump).read_text())
-    if args.limit:
-        rows = rows[: args.limit]
-    asyncio.run(warm_many(rows, refresh=args.refresh, concurrency=args.concurrency))

--- a/backend/labeling/eval/eval_human_corrections.py
+++ b/backend/labeling/eval/eval_human_corrections.py
@@ -1,16 +1,35 @@
-"""Classifier self-critique eval loop.
+"""Classifier self-critique eval loop — RL-inspired 3-phase pipeline.
 
-Pipeline:
-  1. Load validation dump → filter to rows with human corrections.
-  2. For each row: build/load on-chain context (cache), re-run classify_contract.
-  3. Send (ai_rerun, ground_truth, raw_signals, current_system_prompt) to gemini-2.5-pro
-     using META_SYSTEM_INSTRUCTION → structured JSON critique + prompt-edit proposals.
-  4. Persist per_row.jsonl + aggregated report.md.
+Phases:
+  1. CRITIQUE  (--mode critique)   DB-only, no enrichment API calls.
+               Reconstructs raw signals from contract_label_features, runs meta-eval
+               against stored AI output vs human corrections → per_row.jsonl + report.md
+
+  2. SYNTHESIZE (--mode synthesize) One Pro call.
+               Reads per_row.jsonl proposals, calls prompt_synthesizer → candidate_prompt.md
+
+  3. VERIFY   (--mode verify)      Re-enrich + re-classify with candidate prompt.
+               Scores category / name / owner accuracy before vs after → accuracy_report.md
+
+  full        Runs all three phases sequentially.
+  reclassify  Legacy: re-enrich → re-classify (current prompt) → meta-eval (original flow).
 
 CLI:
-  python -m backend.labeling.eval.eval_human_corrections \
-      --dump backend/local/validation_dump_2026-04-25/all_109_combined.json \
-      --run-id 2026-04-27_pass1 [--limit N] [--skip-meta] [--refresh]
+  # Phase 1 — diagnose from stored features (no API cost):
+  python -m backend.labeling.eval.eval_human_corrections \\
+      --source db --mode critique --run-id 2026-05-19_v1 [--limit N] [--skip-meta]
+
+  # Phase 2 — generate improved prompt:
+  python -m backend.labeling.eval.eval_human_corrections \\
+      --mode synthesize --run-id 2026-05-19_v1
+
+  # Phase 3 — verify improvement:
+  python -m backend.labeling.eval.eval_human_corrections \\
+      --source db --mode verify --run-id 2026-05-19_v1
+
+  # All at once:
+  python -m backend.labeling.eval.eval_human_corrections \\
+      --source db --mode full --run-id 2026-05-19_v1
 """
 from __future__ import annotations
 
@@ -19,7 +38,6 @@ import asyncio
 import json
 import logging
 import re
-import ssl
 import sys
 import time
 from collections import Counter, defaultdict
@@ -30,7 +48,7 @@ from typing import Optional
 import aiohttp
 from dotenv import load_dotenv
 
-# ── Path setup (mirror context_cache) ────────────────────────────────────────
+# ── Path setup ────────────────────────────────────────────────────────────────
 _THIS_DIR = Path(__file__).resolve().parent
 _LABELING_DIR = _THIS_DIR.parent
 _BACKEND_DIR = _LABELING_DIR.parent
@@ -45,8 +63,6 @@ load_dotenv(override=False)
 from ai_classifier import classify_contract, _SYSTEM_INSTRUCTION, _get_gemini_client  # noqa: E402
 from google.genai import types as genai_types  # noqa: E402
 
-# Sibling-module imports (this script can be run via `python eval_human_corrections.py`
-# from inside the eval/ dir, or `python -m` from anywhere). Add eval/ to sys.path.
 if str(_THIS_DIR) not in sys.path:
     sys.path.insert(0, str(_THIS_DIR))
 import context_cache as cc  # noqa: E402
@@ -55,36 +71,81 @@ import re_eval_prompt as rep  # noqa: E402
 logger = logging.getLogger("eval.orchestrator")
 
 META_MODEL = "gemini-2.5-pro"
-
 RESULTS_DIR = _BACKEND_DIR / "local" / "eval_results"
 
 
-# ── Filtering ────────────────────────────────────────────────────────────────
+# ── DB loader ────────────────────────────────────────────────────────────────
 
 def load_rows_from_db() -> list[dict]:
-    """Load ground-truth rows by joining contract_label_review (humans) and contract_label_features (AI baseline).
+    """Join contract_label_features (AI baseline + signals) with contract_label_review (human corrections).
 
-    Output schema matches the JSON-dump shape consumed by the rest of the orchestrator.
+    Fetches all feature columns so Phase 1 (critique) can reconstruct raw_signals without
+    any enrichment API calls.
     """
     from src.db_connector import DbConnector
     from sqlalchemy import text as sa_text
     sql = sa_text("""
-        SELECT '0x' || encode(f.address, 'hex')           AS address,
-               f.origin_key                               AS origin_key,
-               f.ai_contract_name                         AS ai_contract_name,
-               f.ai_usage_category                        AS ai_usage_category,
-               f.ai_confidence                            AS confidence,
-               f.ai_reasoning                             AS _comment,
-               f.ai_owner_project_likely                  AS is_protocol_contract_likely,
-               f.ai_model                                 AS _source,
-               r.gtp_contract_name                        AS human_contract_name,
-               r.gtp_usage_category                       AS human_usage_category,
-               r.gtp_owner_project                        AS owner_project_linked,
-               (r.gtp_owner_project IS NOT NULL)          AS gtp_owner_project_confirmed,
-               COALESCE(r.gtp_no_owner_project, false)    AS gtp_no_owner_project,
-               ''::text                                   AS temp_owner_project,
-               ''::text                                   AS human_comment,
-               (r.id IS NOT NULL)                         AS approve
+        SELECT '0x' || encode(f.address, 'hex')                                AS address,
+               f.origin_key                                                    AS origin_key,
+               -- AI output (baseline)
+               f.ai_contract_name                                              AS ai_contract_name,
+               f.ai_usage_category                                             AS ai_usage_category,
+               f.ai_confidence                                                 AS confidence,
+               f.ai_reasoning                                                  AS _comment,
+               f.ai_owner_project_likely                                       AS is_protocol_contract_likely,
+               f.ai_model                                                      AS _source,
+               -- Human corrections
+               r.gtp_contract_name                                             AS human_contract_name,
+               r.gtp_usage_category                                            AS human_usage_category,
+               r.gtp_owner_project                                             AS owner_project_linked,
+               (r.gtp_owner_project IS NOT NULL)                               AS gtp_owner_project_confirmed,
+               COALESCE(r.gtp_no_owner_project, false)                         AS gtp_no_owner_project,
+               ''::text                                                        AS temp_owner_project,
+               ''::text                                                        AS human_comment,
+               (r.id IS NOT NULL)                                              AS approve,
+               -- Blockscout signals
+               f.blockscout_name,
+               f.is_verified,
+               f.is_proxy,
+               CASE WHEN f.impl_address IS NOT NULL
+                    THEN '0x' || encode(f.impl_address, 'hex') END             AS impl_address,
+               f.impl_name,
+               f.has_github_repo,
+               -- Activity metrics
+               f.txcount,
+               f.avg_daa,
+               f.success_rate,
+               f.rel_cost,
+               f.metric_day_range,
+               -- Trace-derived signals
+               f.novel_tokens,
+               f.common_tokens,
+               f.bs_token_transfers,
+               f.matched_routers,
+               f.matched_dex_pools,
+               f.calls_into_dex_pool_swap,
+               f.matched_lending,
+               f.matched_staking,
+               f.matched_bridges,
+               f.matched_oracle_fns,
+               f.delegates_to,
+               f.raw_delegate,
+               f.all_traces_empty,
+               f.traces_only_raw_opcodes,
+               f.named_contracts_in_traces,
+               f.caller_diversity_pct,
+               f.caller_diversity_label,
+               f.unique_callers,
+               -- Log signals
+               f.log_has_access_control,
+               f.log_has_token_transfers,
+               f.log_has_swaps,
+               f.log_has_bridge_events,
+               f.log_has_erc4337,
+               f.log_has_staking,
+               f.log_has_governance,
+               f.log_category_hints,
+               f.log_top_events
         FROM public.contract_label_features f
         LEFT JOIN LATERAL (
             SELECT * FROM public.contract_label_review r2
@@ -105,6 +166,8 @@ def load_rows_from_db() -> list[dict]:
     return rows
 
 
+# ── Filtering helpers ────────────────────────────────────────────────────────
+
 def has_human_correction(row: dict) -> bool:
     """A row counts as ground-truth iff a human supplied at least one signal."""
     if (row.get("human_contract_name") or "").strip():
@@ -112,6 +175,8 @@ def has_human_correction(row: dict) -> bool:
     if (row.get("human_usage_category") or "").strip():
         return True
     if row.get("gtp_owner_project_confirmed") and (row.get("owner_project_linked") or "").strip():
+        return True
+    if bool(row.get("gtp_no_owner_project")):
         return True
     if (row.get("temp_owner_project") or "").strip():
         return True
@@ -144,7 +209,98 @@ def ai_original_block(row: dict) -> dict:
     }
 
 
-# ── Re-classify ──────────────────────────────────────────────────────────────
+# ── Phase 1: reconstruct raw_signals from DB columns ─────────────────────────
+
+def reconstruct_raw_signals_from_features(
+    row: dict,
+    chain_median_map: dict[str, float],
+) -> dict:
+    """Build raw_signals from stored contract_label_features — no API calls.
+
+    Produces a superset of _raw_signals_summary(): includes all old-format fields
+    for backward compat with META_SYSTEM_INSTRUCTION PLUS richer decoded signal groups.
+    """
+    def _lst(v):
+        if v is None:
+            return []
+        return list(v) if not isinstance(v, list) else v
+
+    transfers = _lst(row.get("bs_token_transfers"))
+    named = _lst(row.get("named_contracts_in_traces"))
+
+    # Approximate trace/log counts from stored signals
+    all_empty = bool(row.get("all_traces_empty"))
+    unique_callers = row.get("unique_callers") or 0
+    traces_count_approx = 0 if all_empty else (unique_callers or 1)
+    log_flags = [
+        row.get("log_has_access_control"), row.get("log_has_token_transfers"),
+        row.get("log_has_swaps"), row.get("log_has_bridge_events"),
+        row.get("log_has_erc4337"), row.get("log_has_staking"), row.get("log_has_governance"),
+    ]
+    logs_count_approx = sum(1 for f in log_flags if f)
+
+    return {
+        # ── Old-format fields (backward compat with META_SYSTEM_INSTRUCTION) ──
+        "blockscout": {
+            "contract_name": row.get("blockscout_name"),
+            "is_verified": row.get("is_verified"),
+            "is_proxy": row.get("is_proxy"),
+            "impl_address": row.get("impl_address"),
+            "impl_name": row.get("impl_name"),
+        },
+        "github": {
+            "has_valid_repo": row.get("has_github_repo"),
+        },
+        "metrics": {
+            "txcount": row.get("txcount"),
+            "avg_daa": row.get("avg_daa"),
+            "success_rate": row.get("success_rate"),
+            "rel_cost": row.get("rel_cost"),
+            "day_range": row.get("metric_day_range"),
+            "chain_median_daa": chain_median_map.get(row.get("origin_key", ""), 0.0),
+        },
+        "traces_count": traces_count_approx,
+        "address_logs_count": logs_count_approx,
+        "token_transfers_count": len(transfers),
+        "named_contracts_in_traces_sample": named[:20],
+        "token_transfers_sample": [
+            {"name": t.get("token_name"), "symbol": t.get("token_symbol")}
+            for t in transfers[:10]
+        ],
+        # ── Richer decoded signals (unavailable in legacy _raw_signals_summary) ──
+        "trace_signals": {
+            "matched_routers": _lst(row.get("matched_routers")),
+            "matched_dex_pools": _lst(row.get("matched_dex_pools")),
+            "calls_into_dex_pool_swap": bool(row.get("calls_into_dex_pool_swap")),
+            "matched_lending": _lst(row.get("matched_lending")),
+            "matched_staking": _lst(row.get("matched_staking")),
+            "matched_bridges": _lst(row.get("matched_bridges")),
+            "matched_oracle_fns": _lst(row.get("matched_oracle_fns")),
+            "novel_tokens": _lst(row.get("novel_tokens")),
+            "common_tokens": _lst(row.get("common_tokens")),
+            "all_traces_empty": all_empty,
+            "traces_only_raw_opcodes": bool(row.get("traces_only_raw_opcodes")),
+            "delegates_to": row.get("delegates_to"),
+            "raw_delegate": bool(row.get("raw_delegate")),
+            "caller_diversity_pct": row.get("caller_diversity_pct"),
+            "caller_diversity_label": row.get("caller_diversity_label"),
+            "unique_callers": unique_callers,
+        },
+        "log_signals": {
+            "log_has_access_control": bool(row.get("log_has_access_control")),
+            "log_has_token_transfers": bool(row.get("log_has_token_transfers")),
+            "log_has_swaps": bool(row.get("log_has_swaps")),
+            "log_has_bridge_events": bool(row.get("log_has_bridge_events")),
+            "log_has_erc4337": bool(row.get("log_has_erc4337")),
+            "log_has_staking": bool(row.get("log_has_staking")),
+            "log_has_governance": bool(row.get("log_has_governance")),
+            "log_category_hints": _lst(row.get("log_category_hints")),
+            "log_top_events": row.get("log_top_events") or {},
+        },
+    }
+
+
+# ── Re-classify (used by legacy reclassify mode and Phase 3 verify) ──────────
 
 async def reclassify_row(
     row: dict,
@@ -155,6 +311,7 @@ async def reclassify_row(
     refresh: bool = False,
 ) -> tuple[dict, dict]:
     """Returns (ai_rerun, ctx). ai_rerun is the classifier's full return dict."""
+    from automated_labeler import _is_protocol_likely
     address = row["address"]
     origin_key = row["origin_key"]
     ctx = await cc.build_or_load(
@@ -174,12 +331,17 @@ async def reclassify_row(
             address_logs=ctx.get("address_logs", []),
             token_transfers=ctx.get("token_transfers", []),
         )
+    log_signals = result.get("log_signals") or ctx.get("log_signals") or {}
+    result["ai_owner_project_likely"] = _is_protocol_likely(
+        result, ctx.get("blockscout", {}), log_signals, ctx.get("metrics", {})
+    )
     return result, ctx
 
 
 # ── Meta-eval ────────────────────────────────────────────────────────────────
 
 def _raw_signals_summary(ctx: dict) -> dict:
+    """Build raw_signals from a live enrichment context (legacy / verify mode)."""
     bs = ctx.get("blockscout", {}) or {}
     gh = ctx.get("github", {}) or {}
     metrics = ctx.get("metrics", {}) or {}
@@ -191,10 +353,6 @@ def _raw_signals_summary(ctx: dict) -> dict:
         c.get("contract", "") for t in traces for c in (t.get("protocol_calls") or [])
         if c.get("contract")
     })
-    transfer_summary = [
-        {"name": tt.get("token_name"), "symbol": tt.get("token_symbol")}
-        for tt in transfers[:10]
-    ]
     return {
         "blockscout": {
             "contract_name": bs.get("contract_name"),
@@ -218,15 +376,18 @@ def _raw_signals_summary(ctx: dict) -> dict:
         "address_logs_count": len(logs),
         "token_transfers_count": len(transfers),
         "named_contracts_in_traces_sample": named_in_traces[:20],
-        "token_transfers_sample": transfer_summary,
+        "token_transfers_sample": [
+            {"name": tt.get("token_name"), "symbol": tt.get("token_symbol")}
+            for tt in transfers[:10]
+        ],
     }
 
 
-def _meta_user_message(payload: dict) -> str:
-    """Pack everything the meta-evaluator needs into a single string user message."""
+def _meta_user_message(payload: dict, prompt_override: str | None = None) -> str:
+    prompt = prompt_override if prompt_override is not None else _SYSTEM_INSTRUCTION
     return (
         "CURRENT_SYSTEM_PROMPT:\n"
-        "<<<\n" + _SYSTEM_INSTRUCTION + "\n>>>\n\n"
+        "<<<\n" + prompt + "\n>>>\n\n"
         "GROUND_TRUTH:\n" + json.dumps(payload["ground_truth"], indent=2) + "\n\n"
         "AI_RERUN:\n" + json.dumps(payload["ai_rerun"], indent=2, default=str) + "\n\n"
         "AI_ORIGINAL:\n" + json.dumps(payload["ai_original"], indent=2, default=str) + "\n\n"
@@ -234,9 +395,13 @@ def _meta_user_message(payload: dict) -> str:
     )
 
 
-async def meta_eval(payload: dict, sem: asyncio.Semaphore) -> dict:
+async def meta_eval(
+    payload: dict,
+    sem: asyncio.Semaphore,
+    prompt_override: str | None = None,
+) -> dict:
     client = _get_gemini_client()
-    user_msg = _meta_user_message(payload)
+    user_msg = _meta_user_message(payload, prompt_override=prompt_override)
 
     def _call():
         return client.models.generate_content(
@@ -277,12 +442,10 @@ def aggregate(per_row_path: Path, out_md: Path, run_id: str) -> None:
     rows = [json.loads(line) for line in per_row_path.read_text().splitlines() if line.strip()]
     n = len(rows)
 
-    # Severity histogram
     sev_counts = Counter(r.get("meta_eval", {}).get("severity", "low") for r in rows)
     novel_rows = [r for r in rows if r.get("meta_eval", {}).get("novel_pattern")]
     rows_with_errors = [r for r in rows if r.get("meta_eval", {}).get("errors")]
 
-    # Group errors by (category, root_cause_in_prompt)
     error_buckets: dict[tuple[str, str], list[dict]] = defaultdict(list)
     for r in rows:
         for e in r.get("meta_eval", {}).get("errors", []):
@@ -295,7 +458,6 @@ def aggregate(per_row_path: Path, out_md: Path, run_id: str) -> None:
                 "severity": r.get("meta_eval", {}).get("severity", "low"),
             })
 
-    # Group prompt edits by target_section
     edit_buckets: dict[str, list[dict]] = defaultdict(list)
     for r in rows:
         for p in r.get("meta_eval", {}).get("prompt_edit_proposals", []):
@@ -312,7 +474,8 @@ def aggregate(per_row_path: Path, out_md: Path, run_id: str) -> None:
     lines.append(f"# Classifier eval — run `{run_id}`")
     lines.append("")
     lines.append(f"- Rows evaluated: **{n}**")
-    lines.append(f"- Rows with at least one error: **{len(rows_with_errors)}** ({len(rows_with_errors) / n:.0%} of evaluated)" if n else "- Rows with at least one error: 0")
+    if n:
+        lines.append(f"- Rows with at least one error: **{len(rows_with_errors)}** ({len(rows_with_errors) / n:.0%})")
     lines.append(f"- Severity: high={sev_counts.get('high',0)}  medium={sev_counts.get('medium',0)}  low={sev_counts.get('low',0)}")
     lines.append(f"- Novel-pattern rows: **{len(novel_rows)}**")
     lines.append("")
@@ -349,7 +512,6 @@ def aggregate(per_row_path: Path, out_md: Path, run_id: str) -> None:
     for section, props in sorted_edits:
         avg_conf = sum(p["confidence"] for p in props) / max(len(props), 1)
         lines.append(f"### `{section}`  (proposals: {len(props)}, avg_conf: {avg_conf:.2f})")
-        # Show top-3 distinct proposed_change strings by confidence
         seen: set[str] = set()
         for p in sorted(props, key=lambda x: -x["confidence"]):
             key = p["proposed_change"][:120]
@@ -399,9 +561,414 @@ def aggregate(per_row_path: Path, out_md: Path, run_id: str) -> None:
     logger.info(f"wrote aggregated report → {out_md}")
 
 
-# ── Orchestration ────────────────────────────────────────────────────────────
+# ── Phase 1: critique ────────────────────────────────────────────────────────
 
-async def run(
+async def run_critique_phase(
+    filtered: list[dict],
+    run_id: str,
+    meta_concurrency: int = 3,
+    skip_meta: bool = False,
+) -> Path:
+    """Phase 1: meta-critique from stored features — zero enrichment API calls.
+
+    Uses reconstruct_raw_signals_from_features() to build a richer signal summary
+    than the legacy reclassify flow, then calls meta_eval against the stored AI output.
+    Returns path to per_row.jsonl.
+    """
+    from automated_labeler import fetch_chain_median_daa
+
+    out_dir = RESULTS_DIR / run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    per_row_path = out_dir / "per_row.jsonl"
+    report_path = out_dir / "report.md"
+
+    # One DB query for chain median DAA across all needed origin_keys
+    origin_keys = list({r["origin_key"] for r in filtered})
+    chain_median_map: dict[str, float] = {}
+    try:
+        chain_median_map = fetch_chain_median_daa(origin_keys)
+    except Exception as e:
+        logger.warning(f"chain_median_daa fetch failed: {e} — using 0.0 for all chains")
+
+    meta_sem = asyncio.Semaphore(meta_concurrency)
+    written = 0
+
+    async def _critique_one(row: dict) -> Optional[dict]:
+        ai_orig = ai_original_block(row)
+        raw_signals = reconstruct_raw_signals_from_features(row, chain_median_map)
+        payload = {
+            "address": row["address"],
+            "origin_key": row["origin_key"],
+            "ground_truth": ground_truth_block(row),
+            "ai_original": ai_orig,
+            "ai_rerun": ai_orig,  # no rerun in critique phase — critique the stored output
+            "raw_signals": raw_signals,
+            "phase": "critique",
+        }
+        if not skip_meta:
+            payload["meta_eval"] = await meta_eval(payload, meta_sem)
+        else:
+            payload["meta_eval"] = {
+                "errors": [], "prompt_edit_proposals": [],
+                "severity": "low", "novel_pattern": False, "_skipped": True,
+            }
+        payload["ts"] = datetime.now(timezone.utc).isoformat()
+        return payload
+
+    with per_row_path.open("w") as out_f:
+        results = await asyncio.gather(*(_critique_one(r) for r in filtered))
+        for res in results:
+            if res is None:
+                continue
+            out_f.write(json.dumps(res, default=str) + "\n")
+            written += 1
+
+    logger.info(f"[critique] wrote {written} rows → {per_row_path}")
+    aggregate(per_row_path, report_path, run_id)
+    return per_row_path
+
+
+# ── Phase 3: verify ──────────────────────────────────────────────────────────
+
+def _name_word_overlap(a: str, b: str) -> float:
+    """Normalized word overlap between two contract names (case-insensitive)."""
+    wa = set(a.lower().split())
+    wb = set(b.lower().split())
+    if not wa or not wb:
+        return 0.0
+    return len(wa & wb) / max(len(wa), len(wb))
+
+
+def score_accuracy(rows: list[dict]) -> dict:
+    """Compare ai_original and ai_rerun against ground_truth per correction dimension."""
+    n = len(rows)
+    cat_orig = cat_new = cat_total = 0
+    cat_wins = cat_regressions = 0
+    cat_confusion: Counter = Counter()  # (gt, predicted_new) for wrong new predictions
+
+    name_orig = name_new = name_total = 0
+    name_partial_orig = name_partial_new = 0  # word-overlap >= 0.5
+
+    owner_orig = owner_new = owner_total = 0
+    no_owner_orig = no_owner_new = no_owner_total = 0  # gtp_no_owner_project cases
+
+    conf_buckets: dict[str, list[int]] = {"high": [], "mid": [], "low": []}
+
+    for r in rows:
+        gt = r.get("ground_truth", {})
+        ao = r.get("ai_original", {})
+        ar = r.get("ai_rerun", {})
+
+        # ── Category ──────────────────────────────────────────────────────────
+        human_cat = (gt.get("human_usage_category") or "").strip()
+        if human_cat:
+            cat_total += 1
+            orig_right = ao.get("usage_category") == human_cat
+            new_right = ar.get("usage_category") == human_cat
+            if orig_right:
+                cat_orig += 1
+            if new_right:
+                cat_new += 1
+            if not orig_right and new_right:
+                cat_wins += 1
+            if orig_right and not new_right:
+                cat_regressions += 1
+            if not new_right:
+                cat_confusion[(human_cat, ar.get("usage_category", "?"))] += 1
+
+            # Confidence calibration on new predictions
+            conf = float(ar.get("confidence") or 0)
+            bucket = "high" if conf >= 0.8 else ("mid" if conf >= 0.5 else "low")
+            conf_buckets[bucket].append(1 if new_right else 0)
+
+        # ── Name ──────────────────────────────────────────────────────────────
+        human_name = (gt.get("human_contract_name") or "").strip()
+        if human_name:
+            name_total += 1
+            orig_name = (ao.get("contract_name") or "").lower()
+            new_name = (ar.get("contract_name") or "").lower()
+            gt_name = human_name.lower()
+            if orig_name == gt_name:
+                name_orig += 1
+            if new_name == gt_name:
+                name_new += 1
+            if _name_word_overlap(orig_name, gt_name) >= 0.5:
+                name_partial_orig += 1
+            if _name_word_overlap(new_name, gt_name) >= 0.5:
+                name_partial_new += 1
+
+        # ── Owner: confirmed owner ─────────────────────────────────────────────
+        if gt.get("gtp_owner_project_confirmed") and (gt.get("owner_project_linked") or "").strip():
+            owner_total += 1
+            if bool(ao.get("is_protocol_contract_likely")):
+                owner_orig += 1
+            if bool(ar.get("ai_owner_project_likely")):
+                owner_new += 1
+
+        # ── Owner: confirmed NO owner ──────────────────────────────────────────
+        if bool(gt.get("gtp_no_owner_project")):
+            no_owner_total += 1
+            # Correct = model did NOT flag as protocol_likely
+            if not bool(ao.get("is_protocol_contract_likely")):
+                no_owner_orig += 1
+            if not bool(ar.get("ai_owner_project_likely")):
+                no_owner_new += 1
+
+    def _pct(num: int, den: int) -> Optional[float]:
+        return round(num / den * 100, 1) if den else None
+
+    def _conf_acc(hits: list[int]) -> Optional[float]:
+        return round(sum(hits) / len(hits) * 100, 1) if hits else None
+
+    return {
+        "n": n,
+        "category": {
+            "total_corrected": cat_total,
+            "original_correct": cat_orig,
+            "new_correct": cat_new,
+            "original_pct": _pct(cat_orig, cat_total),
+            "new_pct": _pct(cat_new, cat_total),
+            "wins": cat_wins,
+            "regressions": cat_regressions,
+            "confusion": [
+                {"gt": gt, "predicted": pred, "count": cnt}
+                for (gt, pred), cnt in cat_confusion.most_common(15)
+            ],
+        },
+        "name": {
+            "total_corrected": name_total,
+            "original_correct": name_orig,
+            "new_correct": name_new,
+            "original_pct": _pct(name_orig, name_total),
+            "new_pct": _pct(name_new, name_total),
+            "partial_original_correct": name_partial_orig,
+            "partial_new_correct": name_partial_new,
+            "partial_original_pct": _pct(name_partial_orig, name_total),
+            "partial_new_pct": _pct(name_partial_new, name_total),
+        },
+        "owner_confirmed": {
+            "total": owner_total,
+            "original_correct": owner_orig,
+            "new_correct": owner_new,
+            "original_pct": _pct(owner_orig, owner_total),
+            "new_pct": _pct(owner_new, owner_total),
+        },
+        "no_owner_confirmed": {
+            "total": no_owner_total,
+            "original_correct": no_owner_orig,
+            "new_correct": no_owner_new,
+            "original_pct": _pct(no_owner_orig, no_owner_total),
+            "new_pct": _pct(no_owner_new, no_owner_total),
+        },
+        "confidence": {
+            "high_acc": _conf_acc(conf_buckets["high"]),
+            "high_n": len(conf_buckets["high"]),
+            "mid_acc": _conf_acc(conf_buckets["mid"]),
+            "mid_n": len(conf_buckets["mid"]),
+            "low_acc": _conf_acc(conf_buckets["low"]),
+            "low_n": len(conf_buckets["low"]),
+        },
+    }
+
+
+def _write_accuracy_report(
+    accuracy: dict,
+    path: Path,
+    run_id: str,
+    candidate_prompt_path: Path,
+) -> None:
+    def _delta(orig_pct, new_pct) -> str:
+        if orig_pct is None or new_pct is None:
+            return "n/a"
+        d = new_pct - orig_pct
+        return f"+{d:.1f}%" if d >= 0 else f"{d:.1f}%"
+
+    cat = accuracy["category"]
+    name = accuracy["name"]
+    oc = accuracy["owner_confirmed"]
+    noc = accuracy["no_owner_confirmed"]
+    conf = accuracy["confidence"]
+
+    lines = [
+        f"# Accuracy Report — run `{run_id}`",
+        "",
+        f"Candidate prompt: `{candidate_prompt_path}`",
+        f"Rows verified: **{accuracy['n']}** (human-corrected subset — AI was wrong on all of these originally)",
+        "",
+        "## Category accuracy",
+        "",
+        f"| | Original | New prompt | Delta |",
+        "|---|---|---|---|",
+        f"| Correct | {cat['original_correct']}/{cat['total_corrected']} ({cat['original_pct']}%) | {cat['new_correct']}/{cat['total_corrected']} ({cat['new_pct']}%) | {_delta(cat['original_pct'], cat['new_pct'])} |",
+        "",
+        f"**Wins** (wrong→right): {cat['wins']}  |  **Regressions** (right→wrong): {cat['regressions']}",
+        "",
+    ]
+
+    if cat.get("confusion"):
+        lines += [
+            "### Remaining errors — confusion (ground truth → predicted)",
+            "",
+            "| Ground truth | Predicted | Count |",
+            "|---|---|---|",
+        ]
+        for entry in cat["confusion"]:
+            lines.append(f"| {entry['gt']} | {entry['predicted']} | {entry['count']} |")
+        lines.append("")
+
+    lines += [
+        "## Name accuracy",
+        "",
+        "| Match type | Original | New prompt | Delta |",
+        "|---|---|---|---|",
+        f"| Exact | {name['original_correct']}/{name['total_corrected']} ({name['original_pct']}%) | {name['new_correct']}/{name['total_corrected']} ({name['new_pct']}%) | {_delta(name['original_pct'], name['new_pct'])} |",
+        f"| Partial (≥50% word overlap) | {name['partial_original_correct']}/{name['total_corrected']} ({name['partial_original_pct']}%) | {name['partial_new_correct']}/{name['total_corrected']} ({name['partial_new_pct']}%) | {_delta(name['partial_original_pct'], name['partial_new_pct'])} |",
+        "",
+        "## Owner / protocol detection",
+        "",
+        "| Case | Original | New prompt | Delta |",
+        "|---|---|---|---|",
+    ]
+
+    if oc["total"]:
+        lines.append(
+            f"| Confirmed owner → protocol_likely=True | {oc['original_correct']}/{oc['total']} ({oc['original_pct']}%) | {oc['new_correct']}/{oc['total']} ({oc['new_pct']}%) | {_delta(oc['original_pct'], oc['new_pct'])} |"
+        )
+    if noc["total"]:
+        lines.append(
+            f"| Confirmed no-owner → protocol_likely=False | {noc['original_correct']}/{noc['total']} ({noc['original_pct']}%) | {noc['new_correct']}/{noc['total']} ({noc['new_pct']}%) | {_delta(noc['original_pct'], noc['new_pct'])} |"
+        )
+
+    lines += [
+        "",
+        "## Confidence calibration (new prompt, category accuracy by tier)",
+        "",
+        "| Confidence tier | Rows | Category accuracy |",
+        "|---|---|---|",
+        f"| High (≥0.8) | {conf['high_n']} | {conf['high_acc']}% |",
+        f"| Mid (0.5–0.8) | {conf['mid_n']} | {conf['mid_acc']}% |",
+        f"| Low (<0.5) | {conf['low_n']} | {conf['low_acc']}% |",
+        "",
+    ]
+
+    path.write_text("\n".join(lines) + "\n")
+    logger.info(f"wrote accuracy report → {path}")
+
+
+async def run_verify_phase(
+    filtered: list[dict],
+    run_id: str,
+    candidate_prompt_path: Path,
+    classify_concurrency: int = 3,
+    meta_concurrency: int = 3,
+    refresh: bool = False,
+) -> None:
+    """Phase 3: re-enrich + re-classify with the candidate prompt, score accuracy vs original."""
+    import ai_classifier as _ai_cls
+
+    candidate_prompt = candidate_prompt_path.read_text().strip()
+    original_prompt = _ai_cls._SYSTEM_INSTRUCTION
+
+    out_dir = RESULTS_DIR / run_id
+    verify_jsonl = out_dir / "verify_per_row.jsonl"
+    accuracy_path = out_dir / "accuracy_report.md"
+
+    # Load Phase 1 critique results for per-row baseline severity
+    critique_by_key: dict[str, dict] = {}
+    critique_path = out_dir / "per_row.jsonl"
+    if critique_path.exists():
+        for line in critique_path.read_text().splitlines():
+            if line.strip():
+                r = json.loads(line)
+                critique_by_key[f"{r['origin_key']}/{r['address']}"] = r
+
+    try:
+        from src.db_connector import DbConnector
+        from automated_labeler import _load_chain_config
+        _load_chain_config(DbConnector().engine)
+    except Exception as e:
+        logger.warning(f"chain config load skipped: {e}")
+
+    # Override classifier prompt for this phase (all tasks use the same new prompt)
+    _ai_cls._SYSTEM_INSTRUCTION = candidate_prompt
+    logger.info(f"[verify] classifier prompt overridden with {candidate_prompt_path}")
+
+    all_results: list[dict] = []
+    written = 0
+    total = len(filtered)
+    completed = 0
+
+    try:
+        connector = aiohttp.TCPConnector(ssl=cc._ssl_ctx(), limit=20)
+        enrich_sem = asyncio.Semaphore(3)
+        github_sem = asyncio.Semaphore(2)
+        classify_sem = asyncio.Semaphore(classify_concurrency)
+        meta_sem = asyncio.Semaphore(meta_concurrency)
+
+        async def _verify_one(row: dict) -> Optional[dict]:
+            nonlocal completed
+            addr = row.get('address', '?')
+            ok = row.get('origin_key', '?')
+            try:
+                ai_rerun, ctx = await reclassify_row(
+                    row, session, enrich_sem, github_sem, classify_sem, refresh=refresh
+                )
+            except Exception as e:
+                completed += 1
+                logger.error(f"[verify] [{completed}/{total}] FAILED {ok}/{addr}: {e}")
+                return None
+
+            key = f"{row['origin_key']}/{row['address']}"
+            orig_critique = critique_by_key.get(key, {})
+            raw = _raw_signals_summary(ctx)
+
+            payload = {
+                "address": row["address"],
+                "origin_key": row["origin_key"],
+                "ground_truth": ground_truth_block(row),
+                "ai_original": ai_original_block(row),
+                "ai_rerun": ai_rerun,
+                "raw_signals": raw,
+            }
+            result = {
+                **payload,
+                "meta_eval_original": orig_critique.get("meta_eval", {}),
+                # meta_eval now critiques the rerun against the NEW prompt
+                "meta_eval": await meta_eval(payload, meta_sem,
+                                             prompt_override=candidate_prompt),
+                "phase": "verify",
+                "ts": datetime.now(timezone.utc).isoformat(),
+            }
+            completed += 1
+            cat = ai_rerun.get("usage_category", "?")
+            gt_cat = payload["ground_truth"].get("human_usage_category") or payload["ground_truth"].get("usage_category", "?")
+            match = "✓" if cat == gt_cat else "✗"
+            logger.info(f"[verify] [{completed}/{total}] {match} {ok}/{addr[:10]}… → {cat} (gt={gt_cat})")
+            return result
+
+        with verify_jsonl.open("w") as out_f:
+            async with aiohttp.ClientSession(connector=connector) as session:
+                logger.info(f"[verify] starting {total} rows (concurrency: enrich={enrich_sem._value} classify={classify_sem._value})")
+                results = await asyncio.gather(*(_verify_one(r) for r in filtered))
+                for res in results:
+                    if res is None:
+                        continue
+                    out_f.write(json.dumps(res, default=str) + "\n")
+                    written += 1
+                    all_results.append(res)
+
+    finally:
+        _ai_cls._SYSTEM_INSTRUCTION = original_prompt
+        logger.info("[verify] classifier prompt restored to original")
+
+    logger.info(f"[verify] wrote {written} rows → {verify_jsonl}")
+    accuracy = score_accuracy(all_results)
+    _write_accuracy_report(accuracy, accuracy_path, run_id, candidate_prompt_path)
+
+
+# ── Legacy: reclassify mode (original pipeline) ───────────────────────────────
+
+async def run_reclassify(
     dump_path: Path,
     run_id: str,
     limit: int = 0,
@@ -409,23 +976,23 @@ async def run(
     refresh: bool = False,
     classify_concurrency: int = 3,
     meta_concurrency: int = 3,
-    source: str = 'json',
+    source: str = "json",
 ) -> None:
-    if source == 'db':
+    """Original pipeline: re-enrich → re-classify (current prompt) → meta-eval."""
+    if source == "db":
         rows = load_rows_from_db()
     else:
         rows = json.loads(dump_path.read_text())
     filtered = [r for r in rows if r.get("address") and r.get("origin_key") and has_human_correction(r)]
     if limit:
         filtered = filtered[:limit]
-    logger.info(f"{len(filtered)}/{len(rows)} rows have human corrections (limit={limit or 'none'})")
+    logger.info(f"[reclassify] {len(filtered)}/{len(rows)} rows (limit={limit or 'none'})")
 
     out_dir = RESULTS_DIR / run_id
     out_dir.mkdir(parents=True, exist_ok=True)
     per_row_path = out_dir / "per_row.jsonl"
     report_path = out_dir / "report.md"
 
-    # Lazy chain config (DB)
     try:
         from src.db_connector import DbConnector
         from automated_labeler import _load_chain_config
@@ -442,7 +1009,6 @@ async def run(
     written = 0
     with per_row_path.open("w") as out_f:
         async with aiohttp.ClientSession(connector=connector) as session:
-
             async def _process(row: dict) -> Optional[dict]:
                 try:
                     ai_rerun, ctx = await reclassify_row(
@@ -451,7 +1017,6 @@ async def run(
                 except Exception as e:
                     logger.error(f"reclassify failed for {row.get('address')}: {e}")
                     return None
-
                 payload = {
                     "address": row["address"],
                     "origin_key": row["origin_key"],
@@ -459,6 +1024,7 @@ async def run(
                     "ai_original": ai_original_block(row),
                     "ai_rerun": ai_rerun,
                     "raw_signals": _raw_signals_summary(ctx),
+                    "phase": "reclassify",
                 }
                 if not skip_meta:
                     payload["meta_eval"] = await meta_eval(payload, meta_sem)
@@ -477,35 +1043,229 @@ async def run(
                 out_f.write(json.dumps(res, default=str) + "\n")
                 written += 1
 
-    logger.info(f"wrote {written} rows → {per_row_path}")
+    logger.info(f"[reclassify] wrote {written} rows → {per_row_path}")
     aggregate(per_row_path, report_path, run_id)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def _load_filtered_rows(args) -> list[dict]:
+    if args.source == "db":
+        rows = load_rows_from_db()
+    else:
+        rows = json.loads(Path(args.dump).read_text())
+    filtered = [r for r in rows if r.get("address") and r.get("origin_key") and has_human_correction(r)]
+    if args.limit:
+        filtered = filtered[:args.limit]
+    logger.info(f"{len(filtered)}/{len(rows)} rows have human corrections (limit={args.limit or 'none'})")
+    return filtered
+
+
+PROMPTS_DIR = _LABELING_DIR / "prompts"
+VERSIONS_FILE = PROMPTS_DIR / "versions.json"
+
+
+def _load_versions() -> dict:
+    PROMPTS_DIR.mkdir(exist_ok=True)
+    if VERSIONS_FILE.exists():
+        return json.loads(VERSIONS_FILE.read_text())
+    return {"current": None, "history": []}
+
+
+def _save_versions(v: dict) -> None:
+    VERSIONS_FILE.write_text(json.dumps(v, indent=2))
+
+
+def _next_version(history: list) -> str:
+    if not history:
+        return "v1"
+    nums = []
+    for entry in history:
+        m = __import__("re").match(r"v(\d+)$", entry.get("version", ""))
+        if m:
+            nums.append(int(m.group(1)))
+    return f"v{max(nums) + 1}" if nums else "v1"
+
+
+def _extract_accuracy_summary(run_id: str) -> dict:
+    """Pull key metrics from accuracy_report if it exists for this run."""
+    report_path = RESULTS_DIR / run_id / "accuracy_report.md"
+    if not report_path.exists():
+        return {}
+    text = report_path.read_text()
+    summary = {}
+    for line in text.splitlines():
+        if line.startswith("| Correct") and "%" in line:
+            parts = [p.strip() for p in line.split("|") if p.strip()]
+            if len(parts) >= 3:
+                summary["category_new"] = parts[2]
+        if line.startswith("| Exact") and "%" in line:
+            parts = [p.strip() for p in line.split("|") if p.strip()]
+            if len(parts) >= 3:
+                summary["name_exact_new"] = parts[2]
+        if "Wins" in line and "Regressions" in line:
+            summary["wins_regressions"] = line.strip().lstrip("**").rstrip("**")
+    return summary
+
+
+def deploy_candidate_prompt(candidate_path: Path, run_id: str) -> None:
+    """Write candidate_prompt.md into _SYSTEM_INSTRUCTION in ai_classifier.py.
+
+    Also versions the prompt in backend/labeling/prompts/:
+      - saves it as vN.md
+      - updates versions.json (current pointer + history)
+      - writes current.md as a copy of the active prompt
+    """
+    import re as _re
+
+    classifier_path = _LABELING_DIR / "ai_classifier.py"
+    if not classifier_path.exists():
+        raise FileNotFoundError(f"ai_classifier.py not found at {classifier_path}")
+
+    new_prompt = candidate_path.read_text().strip()
+    source = classifier_path.read_text()
+
+    pattern = r'(_SYSTEM_INSTRUCTION\s*=\s*""")(.*?)(""")'
+    match = _re.search(pattern, source, _re.DOTALL)
+    if not match:
+        raise ValueError(
+            "_SYSTEM_INSTRUCTION triple-quoted string not found in ai_classifier.py. "
+            "Check the assignment format."
+        )
+
+    old_prompt = match.group(2).strip()
+    if old_prompt == new_prompt:
+        logger.info("[deploy] _SYSTEM_INSTRUCTION is already up to date — nothing to do.")
+        return
+
+    # ── Version the new prompt ────────────────────────────────────────────────
+    PROMPTS_DIR.mkdir(exist_ok=True)
+    versions = _load_versions()
+    version = _next_version(versions["history"])
+    versioned_path = PROMPTS_DIR / f"{version}.md"
+    versioned_path.write_text(new_prompt)
+
+    # current.md always reflects what's live in ai_classifier.py
+    (PROMPTS_DIR / "current.md").write_text(new_prompt)
+
+    accuracy = _extract_accuracy_summary(run_id)
+    entry = {
+        "version": version,
+        "run_id": run_id,
+        "deployed_at": datetime.now(timezone.utc).isoformat(),
+        "lines": len(new_prompt.splitlines()),
+        "accuracy": accuracy,
+    }
+    versions["current"] = version
+    versions["history"].append(entry)
+    _save_versions(versions)
+    logger.info(f"[deploy] versioned prompt → {versioned_path} (current={version})")
+
+    # ── Archive the outgoing prompt as previous version entry ─────────────────
+    # Find its version in history (it's the entry before the one we just added)
+    prev_entries = [e for e in versions["history"][:-1]]
+    prev_version = prev_entries[-1]["version"] if prev_entries else "unknown"
+
+    # ── Patch ai_classifier.py ────────────────────────────────────────────────
+    updated = source[: match.start(2)] + "\n" + new_prompt + "\n" + source[match.end(2):]
+    classifier_path.write_text(updated)
+
+    added = len(new_prompt.splitlines()) - len(old_prompt.splitlines())
+    sign = "+" if added >= 0 else ""
+    logger.info(
+        f"[deploy] {prev_version} → {version}: updated _SYSTEM_INSTRUCTION "
+        f"({sign}{added} lines, run_id={run_id})"
+    )
+    if accuracy:
+        logger.info(f"[deploy] accuracy: {accuracy}")
 
 
 def main():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
 
     ap = argparse.ArgumentParser()
-    ap.add_argument("--source", choices=["json", "db"], default="json",
-                    help="json=read from --dump file; db=join contract_label_features + contract_label_review")
-    ap.add_argument("--dump", default=str(_BACKEND_DIR / "local/validation_dump_2026-04-25/all_109_combined.json"))
+    ap.add_argument(
+        "--mode",
+        choices=["critique", "synthesize", "verify", "full", "deploy", "reclassify"],
+        default="critique",
+        help=(
+            "critique   = Phase 1: DB-only meta-critique from stored features (no enrichment API)\n"
+            "synthesize = Phase 2: aggregate proposals → candidate improved prompt\n"
+            "verify     = Phase 3: re-enrich + re-classify with candidate prompt, score accuracy\n"
+            "full       = all three phases sequentially\n"
+            "deploy     = write candidate_prompt.md into _SYSTEM_INSTRUCTION in ai_classifier.py\n"
+            "reclassify = legacy: re-enrich → re-classify (current prompt) → meta-eval"
+        ),
+    )
+    ap.add_argument("--source", choices=["json", "db"], default="db",
+                    help="json=read from --dump; db=join contract_label_features + contract_label_review")
+    ap.add_argument("--dump",
+                    help="Path to JSON dump file (--source json only)")
     ap.add_argument("--run-id", default=time.strftime("%Y-%m-%d_%H%M%S"))
     ap.add_argument("--limit", type=int, default=0)
     ap.add_argument("--skip-meta", action="store_true")
-    ap.add_argument("--refresh", action="store_true")
+    ap.add_argument("--refresh", action="store_true",
+                    help="Force re-fetch enrichment cache (verify/reclassify modes only)")
     ap.add_argument("--classify-concurrency", type=int, default=3)
     ap.add_argument("--meta-concurrency", type=int, default=3)
+    ap.add_argument("--candidate-prompt",
+                    help="Path to candidate prompt file (verify mode; defaults to <run-id>/candidate_prompt.md)")
     args = ap.parse_args()
 
-    asyncio.run(run(
-        dump_path=Path(args.dump),
-        run_id=args.run_id,
-        limit=args.limit,
-        skip_meta=args.skip_meta,
-        refresh=args.refresh,
-        classify_concurrency=args.classify_concurrency,
-        meta_concurrency=args.meta_concurrency,
-        source=args.source,
-    ))
+    run_id = args.run_id
+
+    if args.mode in ("critique", "verify", "full", "reclassify"):
+        filtered = _load_filtered_rows(args)
+
+    if args.mode in ("critique", "full"):
+        asyncio.run(run_critique_phase(
+            filtered, run_id,
+            meta_concurrency=args.meta_concurrency,
+            skip_meta=args.skip_meta,
+        ))
+
+    if args.mode in ("synthesize", "full"):
+        from prompt_synthesizer import synthesize_from_run
+        asyncio.run(synthesize_from_run(run_id))
+
+    if args.mode in ("verify", "full"):
+        candidate_path = (
+            Path(args.candidate_prompt) if args.candidate_prompt
+            else RESULTS_DIR / run_id / "candidate_prompt.md"
+        )
+        if not candidate_path.exists():
+            raise FileNotFoundError(
+                f"Candidate prompt not found: {candidate_path}. Run --mode synthesize first."
+            )
+        asyncio.run(run_verify_phase(
+            filtered, run_id, candidate_path,
+            classify_concurrency=args.classify_concurrency,
+            meta_concurrency=args.meta_concurrency,
+            refresh=args.refresh,
+        ))
+
+    if args.mode == "deploy":
+        candidate_path = (
+            Path(args.candidate_prompt) if args.candidate_prompt
+            else RESULTS_DIR / run_id / "candidate_prompt.md"
+        )
+        if not candidate_path.exists():
+            raise FileNotFoundError(
+                f"Candidate prompt not found: {candidate_path}. Run --mode synthesize first."
+            )
+        deploy_candidate_prompt(candidate_path, run_id)
+
+    if args.mode == "reclassify":
+        asyncio.run(run_reclassify(
+            dump_path=Path(args.dump),
+            run_id=run_id,
+            limit=args.limit,
+            skip_meta=args.skip_meta,
+            refresh=args.refresh,
+            classify_concurrency=args.classify_concurrency,
+            meta_concurrency=args.meta_concurrency,
+            source=args.source,
+        ))
 
 
 if __name__ == "__main__":

--- a/backend/labeling/eval/prompt_synthesizer.py
+++ b/backend/labeling/eval/prompt_synthesizer.py
@@ -1,0 +1,198 @@
+"""Phase 2: aggregate per-row prompt-edit proposals → candidate improved _SYSTEM_INSTRUCTION.
+
+Reads per_row.jsonl from a critique run, ranks proposals by (count × avg_confidence),
+passes them to gemini-2.5-pro with SYNTHESIS_SYSTEM_INSTRUCTION, and writes:
+  - candidate_prompt.md       — the complete revised _SYSTEM_INSTRUCTION
+  - candidate_prompt_changelog.md — what changed and why
+
+CLI (via eval_human_corrections.py --mode synthesize):
+  python -m backend.labeling.eval.eval_human_corrections --mode synthesize --run-id <run-id>
+
+Or directly:
+  python backend/labeling/eval/prompt_synthesizer.py --run-id <run-id>
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_THIS_DIR = Path(__file__).resolve().parent
+_LABELING_DIR = _THIS_DIR.parent
+_BACKEND_DIR = _LABELING_DIR.parent
+_REPO_ROOT = _BACKEND_DIR.parent
+for _p in [str(_LABELING_DIR), str(_BACKEND_DIR)]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+load_dotenv(dotenv_path=_BACKEND_DIR / ".env", override=False)
+load_dotenv(dotenv_path=_REPO_ROOT / ".env", override=False)
+load_dotenv(override=False)
+
+if str(_THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(_THIS_DIR))
+
+from ai_classifier import _SYSTEM_INSTRUCTION, _get_gemini_client  # noqa: E402
+from google.genai import types as genai_types  # noqa: E402
+import re_eval_prompt as rep  # noqa: E402
+
+logger = logging.getLogger("eval.synthesizer")
+
+SYNTHESIS_MODEL = "gemini-2.5-pro"
+RESULTS_DIR = _BACKEND_DIR / "local" / "eval_results"
+
+
+def _aggregate_proposals(per_row_path: Path) -> list[dict]:
+    """Read per_row.jsonl → rank proposals by (count × avg_confidence) descending."""
+    buckets: dict[str, list[dict]] = defaultdict(list)
+    for line in per_row_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        for p in r.get("meta_eval", {}).get("prompt_edit_proposals", []):
+            section = (p.get("target_section") or "?").strip()
+            buckets[section].append({
+                "proposed_change": p.get("proposed_change", ""),
+                "rationale": p.get("rationale", ""),
+                "confidence": float(p.get("confidence", 0)),
+            })
+
+    ranked: list[dict] = []
+    for section, props in buckets.items():
+        count = len(props)
+        avg_conf = sum(p["confidence"] for p in props) / max(count, 1)
+        score = count * avg_conf
+        # Deduplicate proposals for the same section by proposed_change prefix
+        seen: set[str] = set()
+        deduped = []
+        for p in sorted(props, key=lambda x: -x["confidence"]):
+            key = p["proposed_change"][:100]
+            if key not in seen:
+                seen.add(key)
+                deduped.append(p)
+        ranked.append({
+            "target_section": section,
+            "proposals": deduped,
+            "count": count,
+            "avg_confidence": round(avg_conf, 3),
+            "score": round(score, 3),
+        })
+
+    ranked.sort(key=lambda x: -x["score"])
+    logger.info(f"aggregated {len(ranked)} proposal sections from {per_row_path.name}")
+    return ranked
+
+
+def _build_synthesis_user_message(ranked_proposals: list[dict]) -> str:
+    return (
+        "CURRENT_PROMPT:\n"
+        "<<<\n" + _SYSTEM_INSTRUCTION + "\n>>>\n\n"
+        "RANKED_PROPOSALS:\n"
+        + json.dumps(ranked_proposals, indent=2)
+    )
+
+
+async def synthesize_from_run(run_id: str) -> Path:
+    """Read critique results for run_id, call Pro, write candidate prompt. Returns prompt path."""
+    out_dir = RESULTS_DIR / run_id
+    per_row_path = out_dir / "per_row.jsonl"
+    candidate_path = out_dir / "candidate_prompt.md"
+    changelog_path = out_dir / "candidate_prompt_changelog.md"
+
+    if not per_row_path.exists():
+        raise FileNotFoundError(
+            f"per_row.jsonl not found at {per_row_path}. Run --mode critique first."
+        )
+
+    ranked = _aggregate_proposals(per_row_path)
+    if not ranked:
+        logger.warning("no proposals found in per_row.jsonl — writing unchanged prompt")
+        candidate_path.write_text(_SYSTEM_INSTRUCTION)
+        changelog_path.write_text("# Changelog\n\nNo proposals — prompt unchanged.\n")
+        return candidate_path
+
+    user_msg = _build_synthesis_user_message(ranked)
+    client = _get_gemini_client()
+
+    def _call():
+        return client.models.generate_content(
+            model=SYNTHESIS_MODEL,
+            contents=user_msg,
+            config=genai_types.GenerateContentConfig(
+                system_instruction=rep.SYNTHESIS_SYSTEM_INSTRUCTION,
+                response_mime_type="application/json",
+                response_schema=rep.SYNTHESIS_RESPONSE_SCHEMA,
+                temperature=0.2,
+                max_output_tokens=32768,
+            ),
+        )
+
+    logger.info(f"calling {SYNTHESIS_MODEL} for prompt synthesis ({len(ranked)} proposal sections)...")
+    loop = asyncio.get_event_loop()
+    response = await loop.run_in_executor(None, _call)
+    raw = response.text or ""
+
+    cleaned = re.sub(r",\s*([}\]])", r"\1", raw)
+    try:
+        result = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        logger.error(f"synthesis JSON parse failed: {e} | raw[:300]: {raw[:300]!r}")
+        # Fallback: write unchanged prompt so downstream steps don't hard-fail
+        candidate_path.write_text(_SYSTEM_INSTRUCTION)
+        changelog_path.write_text(f"# Changelog\n\nParse error — prompt unchanged.\n\n```\n{raw[:500]}\n```\n")
+        return candidate_path
+
+    revised = result.get("revised_prompt") or _SYSTEM_INSTRUCTION
+    candidate_path.write_text(revised)
+    logger.info(f"wrote candidate prompt → {candidate_path} ({len(revised)} chars)")
+
+    skip_reason = result.get("skip_reason") or ""
+    changelog = result.get("changelog") or []
+    unchanged = result.get("sections_unchanged") or []
+
+    cl_lines = [f"# Prompt Changelog — run `{run_id}`", ""]
+    if skip_reason:
+        cl_lines.append(f"**No changes applied:** {skip_reason}")
+    else:
+        cl_lines.append(f"**Sections changed: {len(changelog)}**  |  "
+                        f"Sections unchanged: {len(unchanged)}")
+        cl_lines.append("")
+        cl_lines.append("## Changes")
+        cl_lines.append("")
+        for entry in changelog:
+            cl_lines.append(f"### `{entry.get('section', '?')}`")
+            cl_lines.append(entry.get("change_summary", ""))
+            cl_lines.append("")
+        if unchanged:
+            cl_lines.append("## Unchanged sections")
+            cl_lines.append("")
+            for s in unchanged:
+                cl_lines.append(f"- `{s}`")
+    cl_lines.append("")
+    cl_lines.append("## Ranked proposals fed to synthesizer")
+    cl_lines.append("")
+    for p in ranked:
+        cl_lines.append(
+            f"- `{p['target_section']}` — count={p['count']} "
+            f"avg_conf={p['avg_confidence']} score={p['score']}"
+        )
+
+    changelog_path.write_text("\n".join(cl_lines) + "\n")
+    logger.info(f"wrote changelog → {changelog_path}")
+    return candidate_path
+
+
+if __name__ == "__main__":
+    import argparse
+    import time
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run-id", required=True, help="Run ID from a completed critique phase")
+    args = ap.parse_args()
+    asyncio.run(synthesize_from_run(args.run_id))

--- a/backend/labeling/eval/re_eval_prompt.py
+++ b/backend/labeling/eval/re_eval_prompt.py
@@ -27,13 +27,22 @@ You receive five blocks for a single contract:
 
   4. AI_ORIGINAL — the prior production output (may match AI_RERUN; if it differs, the model has drifted).
 
-  5. RAW_SIGNALS — what the classifier actually saw:
-       blockscout : {contract_name, is_verified, is_proxy, impl_address}
-       github     : {has_valid_repo, repo_url}
-       metrics    : {txcount, avg_daa, success_rate, rel_cost, day_range, chain_median_daa}
-       traces     : count + sample of named contracts called
-       address_logs : decoded log signal counts
-       token_transfers : token names/symbols moved through this contract
+  5. RAW_SIGNALS — what the classifier actually saw. Format varies by eval phase:
+       blockscout       : {contract_name, is_verified, is_proxy, impl_address, impl_name}
+       github           : {has_valid_repo}
+       metrics          : {txcount, avg_daa, success_rate, rel_cost, day_range, chain_median_daa}
+       traces_count     : approximate trace sample count (0 when all_traces_empty=true)
+       address_logs_count : count of active log signal categories
+       token_transfers_count / token_transfers_sample : token names/symbols
+       named_contracts_in_traces_sample : up to 20 named contracts called
+       trace_signals (critique mode only) : fully decoded — matched_routers, matched_dex_pools,
+           calls_into_dex_pool_swap, matched_lending, matched_staking, matched_bridges,
+           matched_oracle_fns, novel_tokens, common_tokens, all_traces_empty,
+           traces_only_raw_opcodes, delegates_to, raw_delegate,
+           caller_diversity_pct, caller_diversity_label, unique_callers
+       log_signals (critique mode only) : log_has_access_control, log_has_token_transfers,
+           log_has_swaps, log_has_bridge_events, log_has_erc4337, log_has_staking,
+           log_has_governance, log_category_hints, log_top_events
 
 Your job for each contract:
 
@@ -114,4 +123,70 @@ META_RESPONSE_SCHEMA = {
     },
     "required": ["errors", "prompt_edit_proposals", "severity", "novel_pattern"],
     "propertyOrdering": ["errors", "prompt_edit_proposals", "severity", "novel_pattern"],
+}
+
+
+# ── Phase 2: Prompt Synthesis ─────────────────────────────────────────────────
+
+SYNTHESIS_SYSTEM_INSTRUCTION = """You are a senior prompt engineer refining a smart-contract classifier prompt.
+
+You receive:
+  1. CURRENT_PROMPT — the full _SYSTEM_INSTRUCTION used by Gemini 2.5 Flash to classify contracts.
+  2. RANKED_PROPOSALS — aggregated prompt-edit proposals from a meta-evaluation run, sorted by
+     (count × avg_confidence) descending. Each entry:
+       target_section   : the prompt section to change (verbatim name from the prompt)
+       proposals        : list of {proposed_change, rationale, confidence, count}
+
+Your task:
+
+  A) Apply proposals that meet BOTH thresholds: confidence >= 0.6 AND count >= 2.
+     Also apply any single high-severity proposal (confidence >= 0.85) even if count = 1.
+     Skip proposals that contradict each other for the same section — pick the highest-confidence one.
+
+  B) Output the COMPLETE revised prompt — not a diff. Reproduce every unchanged section verbatim.
+     Only the sections touched by qualifying proposals should differ from CURRENT_PROMPT.
+
+  C) Output a changelog: for each section you changed, one sentence explaining what changed and why.
+     List unchanged sections by name only.
+
+  D) If no proposals meet the thresholds, set revised_prompt = CURRENT_PROMPT verbatim and
+     set skip_reason = "no proposals met confidence/count thresholds".
+
+Hard rules:
+  - Output STRICT JSON. The revised_prompt field is a single string with newlines as \\n.
+  - Preserve all PATH labels (A, B, C, D, E, F, G1, G2, G3, O) — do not renumber them.
+  - Do not invent new categories or paths not already in CURRENT_PROMPT.
+  - Keep property_ordering intact in any schema sections you touch."""
+
+
+SYNTHESIS_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "revised_prompt": {
+            "type": "string",
+            "description": "Complete revised _SYSTEM_INSTRUCTION. Equal to current if no changes.",
+        },
+        "changelog": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "section": {"type": "string"},
+                    "change_summary": {"type": "string"},
+                },
+                "required": ["section", "change_summary"],
+                "propertyOrdering": ["section", "change_summary"],
+            },
+        },
+        "sections_unchanged": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "skip_reason": {
+            "type": "string",
+            "description": "Non-empty only when no changes were applied.",
+        },
+    },
+    "required": ["revised_prompt", "changelog", "sections_unchanged", "skip_reason"],
+    "propertyOrdering": ["revised_prompt", "changelog", "sections_unchanged", "skip_reason"],
 }

--- a/backend/labeling/prompts/current.md
+++ b/backend/labeling/prompts/current.md
@@ -1,0 +1,321 @@
+You are a smart contract protocol analyst. Classify the contract described below by following the decision paths IN ORDER. Stop at the first path that applies.
+
+## is_protocol_contract_likely
+Set to `true` ONLY when there is strong evidence of ownership or public infrastructure: `github.has_valid_repo=true`, a verified name from a known protocol, or high public usage (HIGH-DAA). Do NOT set to `true` for unverified, private-caller contracts based solely on token interactions (`novel_tokens`). Contracts classified as `trading` under PATH G1 or G2 MUST have `protocol_likely=false`, as they are private bots by definition.
+
+## HOW TO CLASSIFY
+
+Three primary sources of truth, in order of reliability:
+1. **Verified name** — if the contract is source-verified with a real name, read it as a human would. "GridMining" is gaming. "LendingPool" is lending. "BridgeRouter" is bridge. Trust your semantic understanding of what the name describes. Use traces to confirm or disambiguate, not to override.
+2. **Trace behavior** — what the contract actually does: what it calls, what events it emits, what state it changes. Classify by function.
+3. **GitHub repository** — if `github.has_valid_repo=true`, the linked repo is a strong identity + ownership signal. Treat it like verification: do NOT default such a contract to trading/MEV in PATH G1/G2/G3 — classify by trace content or name semantics instead.
+
+Numerical signals (success_rate, DAA/tx, rel_cost) are tiebreakers in most cases. They shift
+confidence but do not override clear semantic or trace evidence.
+
+**Exception — avg_daa is a primary signal for public/private classification.**
+A contract with avg_daa ≥ chain_median_daa is public infrastructure by definition (real users from
+many addresses). It cannot be a private trading bot regardless of trace shape. Conversely, a contract
+with avg_daa far below chain_median (single-digit DAA on a chain whose median is hundreds) is a
+private operator, and "DEXAggregator" / "DEX" labels are invalid for it without strong evidence
+that the few callers are real public EOAs (not admin keepers cycling addresses). See the
+"avg_daa Discriminator" section below.
+
+**Output discipline.** The `reasoning` field MUST end with `→ <category>` and that category MUST equal the `usage_category` field. Never conclude `→ trading` (or oracle / bridge / etc.) and then output `usage_category="other"`. If you cannot pick a specific category from the path, conclude `→ other` explicitly.
+
+## DECISION PATHS (follow in order, stop at first match)
+
+### PATH -1 — Zero-Transaction Gate
+IF `txcount` = 0: This contract has never executed. All trace and log signals will be empty. Classify as `other` with name `UnexecutedContract` and low confidence. Stop here.
+
+### PATH 0 — Identity Gate  (RUN FIRST, ALWAYS)
+Before evaluating any other path, evaluate identity:
+
+  IF source_verified=True OR github.has_valid_repo=true:
+    → This contract has confirmed protocol identity. You MUST classify by trace content,
+      verified name, or repository ownership. PATH G1 / G2 / G3 trading defaults DO NOT apply.
+      "PRIVATE callers" alone is NOT grounds for `trading` when identity is confirmed.
+    → Proceed to PATH A (verified) or PATH B (proxy) and continue down the list.
+    → Exception: confirmed-identity contracts whose dominant trace activity is automated LP
+      management (CLPool/CLGauge/NonfungiblePositionManager mint/burn/collect) ARE `trading`,
+      even with confirmed identity. This single exception applies — no other identity-confirmed
+      contract may be classified `trading` based on caller diversity alone.
+    → When `github.has_valid_repo=true`, the linked repository's organization is a strong owner-project signal. You MUST use this to assert `protocol_likely=true` and name the owner project in your reasoning. The repository's identity is a primary classification signal; if the repo name implies a function (e.g., 'ultron-bridge'), use that to determine the category, overriding weaker trace signals.
+
+  IF source_verified=False AND github.has_valid_repo=False:
+    → No confirmed identity. PATH G1 / G2 / G3 caller-based trading defaults apply normally.
+
+### PATH A — Verified + Named Contract
+IF source_verified=True AND blockscout_name != "unknown":
+  → contract_name = exact Blockscout name
+  → Classify by the semantic meaning of the verified name. Read it as a human — you know what protocols do.
+  → Sanity Check: If the name implies a function (e.g., 'Bridge') but all corresponding trace/log signals are negative (`log_has_bridge_events=false`), the name may be misleading; re-evaluate based on other signals.
+  → Use traces to disambiguate when the name alone is genuinely unclear. VRF calls (Chainlink VRF, Pyth) → gaming. NFT interactions without marketplace → gaming or non_fungible_tokens. If `traces_only_raw_opcodes=true`, state that the trace is uninformative; do not invent function calls.
+  → When trace signals are absent because `all_traces_empty=true`, the semantic meaning of the verified name is the sole, authoritative signal. Trust it completely.
+  → The verified name overrides MEV/bot heuristics — do NOT reclassify a named protocol as trading because callers are private or success_rate is low.
+  → Protocol-specific corrections (the name sounds like X but IS actually Y):
+      Permit2, Permit3, AllowanceHolder → developer_tools  (approval middleware, not a DEX router)
+      GPv2Settlement, CoWSwap*, CowSwap*, BatchSettlement → dex  (batch DEX settlement, not a trading bot)
+      Relay*Router, RelayRouter, RelayBridge, RelayReceiver, RelayDepository → bridge
+      Rango*, RangoDiamond → bridge  (bridge aggregator, not dex)
+      *DVN, *Dvn → cc_communication  (LayerZero verifier network)
+      MayanSwift*, Mayan*Bridge → bridge
+      Socket*, SocketGateway, SocketBridge → bridge
+      OffchainAggregator, AccessControlledOffchainAggregator, *EACAggregator*, BlockhashStore → oracle  (Chainlink data feed or utility)
+      OpenOceanSwapModule, OpenOcean*Module → nft_marketplace  (Seaport-bound; classify by host protocol)
+      ConditionalTokens, CTFExchange, NegRiskAdapter → prediction_markets  (Polymarket / Omen pattern)
+      IdRegistry, NameRegistry, *Registrar (Farcaster, ENS, Lens) → identity
+      *Factory, *Deployer, *Creator (deploys other contracts via CREATE/CREATE2) → developer_tools
+        (the factory's role is deployment infra; do not inherit category from what it deploys)
+      TransparentUpgradeableProxy, ERC1967Proxy, ProxyAdmin (when bs_name is exactly that) → developer_tools
+      *Router without clear DEX context → examine trace, do NOT default to dex
+      *FeeForwarder, *FeeProvider, *FeeCollector, *FeeDistributor → payments
+      BatchResolver → gaming
+  → Airdrop/Distribution patterns: If the name contains keywords like Airdrop, Claim, Distributor, Vesting, Launcher, Rewards, or Points, classify as `airdrop`. This pattern overrides a simple token-name match.
+  → Stablecoin token check (W6): if the contract name is a distribution/claim mechanism
+    (Claim, DiamondClaim, Distributor, Airdrop, Vesting) AND traces show transfers of known
+    stablecoin tokens (Tether, TetherToken, USDT, USDC, FiatToken, DAI, BUSD, TUSD, or any
+    token name containing "USD" or "Stablecoin") → stablecoin, NOT fungible_tokens.
+
+### PATH B — Proxy Delegating to Named Implementation
+IF the signal "this contract itself delegates to (named)" is non-null and contains a resolved contract name:
+  → This proxy IS that named implementation. Classify by what the delegate target does.
+  → CLPool / UniswapV3Pool / PancakeV3Pool → dex
+  → EntryPoint → erc4337
+  → FiatToken / USDC / ERC20 → stablecoin or fungible_tokens
+  → RangoDiamond, Rango* → bridge
+  → Relay*Router, RelayRouter* → bridge
+  → Endpoint, EndpointV2, LZEndpoint → bridge (LayerZero endpoint proxy)
+  → Apply same protocol-specific corrections from PATH A for any ambiguous delegate names
+  NOTE (W5): Generic proxy names (TransparentUpgradeableProxy, OptimizedTransparentUpgradeableProxy,
+  ERC1967Proxy, etc.) are stripped before reaching this path — they are treated as "unknown" name.
+  The DELEGATECALL target name IS available in traces as "this contract itself delegates to".
+  Always prefer the delegate target name over the proxy wrapper name.
+
+### PATH C — Calls Official DEX Router (depth ≤1)
+IF "Direct calls into official DEX routers" list is non-empty:
+  → This contract is ABOVE official routers in the stack — an aggregator, bot, or strategy
+  EXCEPTION — verified contracts: do NOT apply the trading default.
+    Verified contracts that call official routers are settlement/fulfillment infrastructure
+    (RFQ market makers, solver contracts, intent-settlement). Prefer dex.
+    Only assign trading if traces show explicit MEV patterns (very low success_rate + clear failed-tx-heavy volume).
+  → Unverified contracts: default to trading unless strong evidence of a public aggregator:
+    - Few unique callers (low DAA/tx) → trading
+    - Many failed txs (low success_rate) → trading, lean high confidence
+    - High DAA/tx + high success_rate → could be public aggregator → dex
+    - Both low DAA/tx AND low success_rate → near-certain private trading
+
+### PATH D — Calls AMM Pool Swap Functions Directly (depth ≤1)
+IF "Direct calls into AMM pool swap functions" = True AND no_meaningful_identity = True:
+  → Calls CLPool.swap / UniswapV3Pool.swap directly (not just price reads)
+  NOTE: AMM pools list non-empty but swap = False → price reads only (slot0, getReserves). Do not use PATH D; fall through to PATH F or G.
+  → PRIMARY: caller pattern — PRIVATE callers → trading; DIVERSE callers → dex
+  → SECONDARY: success_rate < 50% → aggressive bot → trading; ≥70% + diverse → dex
+  → TERTIARY (no caller data): low DAA/tx → trading; high DAA/tx → dex
+
+### PATH E — EIP-1167 Minimal Clone (Empty Trace)
+IF "this contract has raw-address DELEGATE" = True AND "all trace call graphs empty" = True:
+  → Factory clone forwarding to unresolvable implementation
+  → PRIVATE callers → trading executor; DIVERSE callers → dex infrastructure clone
+  → Use txcount as a tiebreaker when caller data is unavailable: high volume → trading, low → dex
+  → Confidence is inherently limited — cannot fully resolve without the implementation
+
+### PATH F — Pure Price Scanner
+IF trace contains ONLY STATICCALL/SLOAD ops AND calls are exclusively slot0/price-read functions
+   (slot0, observe, getReserves, latestRoundData) across multiple pools AND no swap/transfer calls:
+  → Hunts opportunities without executing — Searcher or PriceScanner
+  → usage_category = trading
+  → Distinguish from oracle consumers: oracle consumers call Chainlink feeds (EACAggregatorProxy);
+    Searchers call AMM pool slot0 across many different pools to compare prices
+
+### PATH O — Oracle Infrastructure
+IF "Oracle function calls detected" list is non-empty AND those functions are central
+   (entry method OR matched in the majority of traces):
+  → Oracle-specific functions: storkPublicKey, latestRoundData, latestAnswer, updatePriceFeed,
+    updatePrices, postPrices, parsePriceFeedUpdates, transmit, fulfillOracleRequest, fulfillOracleRequest2.
+    A contract whose entry method is updatePrices/updatePriceFeed is an oracle pusher — classify oracle
+    even when callers are PRIVATE (single operator) or PUBLIC (decentralized network).
+  → usage_category = oracle  (this is sticky — once chosen, do not fall back to "other" later in reasoning)
+  → Name: "[Protocol]Oracle", "[Protocol]PriceFeed", or "[Protocol]OracleProxy" depending on trace depth.
+    If DELEGATECALL to oracle → it IS the oracle (proxy). If CALL → it USES the oracle (consumer).
+    Chainlink Operator contracts (calling fulfillOracleRequest/transmit) are oracle, not their host protocol.
+  → Override for unverified contracts with PRIVATE callers — a single-operator oracle updater
+    is still oracle infrastructure, not a trading bot.
+  → Soft exception: if a contract calls one oracle getter incidentally (e.g. latestAnswer once)
+    but the dominant activity is large stablecoin transfers or DEX swaps, classify by the dominant
+    activity instead. Do not treat one oracle getter as conclusive evidence of oracle identity.
+
+### PATH G1 — Private Callers (PRIVATE diversity ≤20%)
+IF caller_diversity_label = "PRIVATE" AND no prior path matched:
+  **STOP: First, check `source_verified` and `github.has_valid_repo`. If either is true, you MUST follow the 'EXCEPTION' logic below. Do not proceed to the 'Unverified private callers' section.**
+  **CRITICAL: This path applies even when traces are raw opcodes only and identity is unknown.
+  Raw-opcode traces + PRIVATE callers + no identity IS the trading bot signature — intentionally unverified.
+  Do NOT skip to G0 because traces are unreadable. If the label says PRIVATE, use G1.**
+  EXCEPTION — verified contracts OR `github.has_valid_repo=true`: do NOT apply trading defaults.
+    Contracts with confirmed identity (verified source OR linked GitHub repo) and private callers
+    are almost always protocol infrastructure (vault, liquidator, position manager), not MEV bots.
+    For example, a contract interacting with another contract named 'Rewards' or distributing a protocol's own token is likely `staking` or `airdrop` infrastructure, not `trading`.
+    Classify by trace content; only assign trading if traces explicitly show MEV patterns (raw slot0
+    reads across many pools, failed-tx-heavy swaps).
+  EXCEPTION-TO-EXCEPTION: verified or github-linked contracts that interact directly with
+    LP infrastructure (CLPool/CLGauge/NonfungiblePositionManager, Aerodrome/Velodrome rebalancers)
+    via mint/burn/collect/_collect calls ARE automated trading strategies, not protocol infra.
+    Classify trading even when verified. Name "[Protocol]Rebalancer" or "[Asset]PositionManager"
+    using the underlying-asset rule from §contract_name.
+  VERIFIED + DEX router calls: prefer dex — settlement or fulfillment infrastructure. Use trace entry
+    function to name it (e.g. "RFQSettlement", "FulfillHelper"). Exception: very low success_rate or
+    clear failed-tx patterns → trading still possible.
+  VERIFIED + bridge calls: prefer bridge or cc_communication.
+  → Unverified private callers: TRADING IS THE ONLY VALID CLASSIFICATION. Do not use other.
+    EXCEPTION for low activity: If txcount < 5 AND avg_daa < 1, this is likely a test or deployment artifact, not an active bot. Classify as `other` with the name `LowActivityContract` and stop.
+    A single operator running automated on-chain transactions is by definition a trading bot.
+    Unverified bots intentionally leave no decoded traces — raw opcodes and no identity ARE the signal.
+    "No specific trading signals" is not a valid reason to pick other over trading here.
+    These contracts MUST have `is_protocol_contract_likely=false`.
+    Name it based on available signals, but the category is always trading:
+  - LP/gauge contracts (CLGauge, CLPool, NonfungiblePositionManager) + novel tokens in traces:
+      ACTIVE REBALANCER (slot0 reads + _collect + burns/mints in same tx) → trading, "[Protocol]CLRebalancer"
+      PASSIVE LP MANAGER (only deposit/withdraw/mint/burn, no slot0 reads) → trading, "[Protocol][Token]LPManager"
+      Include token pair in name when identifiable.
+  - Very low success_rate → near-certain MEV/arbitrage → trading, "MEVBot" or "ArbitrageBot"
+  - High success_rate → efficient strategy → trading, "StrategyExecutor"
+  - Raw opcodes only, no decoded calls → trading, "StrategyExecutor"
+  - Truly undifferentiated (no useful signals at all) → trading, "StrategyExecutor"
+  - AccessControl events: confirms permissioned automation, does NOT change category
+
+### PATH G2 — Keeper Callers (KEEPER diversity 20–80%)
+IF caller_diversity_label = "KEEPER" AND no prior path matched:
+  EXCEPTION — verified contracts with named protocol interactions: classify by trace content.
+    Verified keeper contracts are typically protocol infrastructure (liquidators, settlement, distributors).
+    If a verified contract is a proxy delegating to an unverified implementation (raw_delegate=true) and its traces consist only of raw opcodes, its function is ambiguous. Classify as `other` and name it `VerifiedProxyToUnknownImpl`.
+  EXCEPTION-TO-EXCEPTION: verified contracts whose dominant trace activity is automated LP
+    management (CLPool/CLGauge/NonfungiblePositionManager mint/burn/collect) ARE trading.
+  VERIFIED + DEX router calls: KEEPER + verified + DEX router = DEX settlement/aggregation signature
+    (1inch resolvers, CoW solvers, RFQ market makers are all KEEPER callers). Prefer dex.
+  VERIFIED + bridge calls: prefer bridge or cc_communication.
+  → Unverified multi-operator permissioned system. Check explicit protocol signals FIRST before
+    defaulting to trading. Apply these overrides in order even when unverified:
+  1. Interactions with known DEX infrastructure (`named_contracts_in_traces` contains SwapRouter, UniswapV3Pool) → dex.
+  2. "Direct calls into lending protocols" non-empty (Aave, Compound, Morpho, etc.)
+     AND no slot0/price-read pattern → lending (or derivative for perp protocols)
+     Name: "[Protocol]Liquidator" or "[Protocol]KeeperBot"
+  3. "Direct calls into bridge protocols" non-empty (Stargate, LayerZero, Connext, etc.)
+     OR bridge events (MessagePassed, SentMessage, PacketSent) → bridge or cc_communication
+  4. ERC-4337 events (UserOperationEvent, AccountDeployed) → erc4337
+  5. Governance events (ProposalCreated, VoteCast) → governance
+  → After checking the above, if no protocol signal matched:
+  If traces are raw opcodes only with no identity and KEEPER callers, the contract's function is ambiguous. If there are absolutely no other DeFi signals (swaps, lending, LP management), classify as `other` with name `AmbiguousExecutor`. If DeFi signals are present but un-decoded, `trading` with name `StrategyExecutor` is a reasonable fallback.
+  - LP/gauge contracts + novel tokens: same ACTIVE/PASSIVE rebalancer distinction as G1
+  - AccessControl events + no identifiable protocol interactions → trading executor
+  - Known non-trading protocol interactions in traces: classify by what it interacts with
+  - No DeFi signals, specific name: classify by semantic meaning of name. Do NOT default to other.
+  - Truly unclear: use trading as fallback, "StrategyExecutor"
+
+### PATH G3 — Public Callers (PUBLIC diversity ≥80%)
+IF caller_diversity_label = "PUBLIC" AND no prior path matched:
+  → Many different callers — public-facing. Classify by what the contract does.
+  - **Stablecoin name match**: novel_tokens or bs_token_transfers token name/symbol contains
+    USD / Stable / DAI / USDT / USDC / USDM / BUSD / TUSD / FRAX / LUSD AND that token is the
+    primary asset moved. This is a strong signal, but must be confirmed by contract function. Classify as `stablecoin` only when the contract's primary role is distribution (Airdrop, Vesting), minting, or redemption of the stablecoin itself. If traces suggest yield, lending, or staking activity, prefer that category.
+  - **Low success_rate override**: success_rate < 60% with DEX router or pool-swap traces →
+    public arbitrage / sandwich pattern → trading, "MEVBot" or "ArbitrageBot". Many public callers
+    competing and failing is the MEV signature; do NOT classify as dex when most txs revert.
+  - Known DEX interactions (swap events, pool calls) AND success_rate ≥ 60% AND avg_daa qualifies
+    as PUBLIC (see §avg_daa Discriminator below) → dex
+  - Named STATIC calls to EACAggregatorProxy/Chainlink feeds → oracle consumer
+  - Pool-internal math (computeSwapStep, getSqrtRatioAtTick as INTERNAL nodes) → dex
+  - Calls to LayerZero, Wormhole, Axelar, or other cross-chain messaging endpoints → cc_communication
+  - Calls to Relay*, Stargate, Connext, Synapse, Across, deBridge → bridge
+  - Calls to VRF (Chainlink VRF, Pyth randomness) → gaming
+  - Airdrop/Claim/Distributor/Vesting/Rewards/Points patterns with broad user base AND
+    no stablecoin-name match above → airdrop
+  - Stablecoin distribution (FiatToken/USDC/Tether transfers via Claim/Airdrop/Vesting patterns) → stablecoin
+  - Social/check-in pattern (simple state writes per user, no DeFi signals) → community
+  - Calls to `liquidate`, `auction`, `seize`, or `settle` on lending/perp contracts → lending or derivative
+  - No DeFi signals: classify by semantic meaning of the contract name. Do NOT default to other for a specific name.
+  - Truly ambiguous name AND no usable signals → other
+  - IMPORTANT: Named contracts in the DEEP trace are downstream callees — do NOT classify this contract as CLPool just because CLPool appears in the trace.
+
+### avg_daa Discriminator — Trading vs DEXAggregator
+CRITICAL: These DAA gates are mandatory checks that MUST be performed before assigning the `dex` category to any unverified contract in PATH C, D, or G. Your reasoning must explicitly state which DAA tier the contract falls into.
+
+The single strongest signal separating private trading bots from public DEX infrastructure is
+**absolute avg_daa relative to chain_median_daa**. Apply these gates BEFORE picking dex/DEXAggregator:
+
+  HIGH-DAA (avg_daa ≥ chain_median_daa AND avg_daa ≥ 50):
+    → Public infrastructure. Many independent users. Cannot be a private trading bot regardless
+       of how trading-shaped the traces look. Even if the contract calls DEX routers and swaps
+       look bot-like, high public usage rules out trading. Classify dex / bridge / oracle / etc.
+       by trace content. Override "trading bot" heuristics from G1/G2.
+    → Note: 'Public infrastructure' does not automatically mean `protocol_likely=true`. Only assert `protocol_likely=true` if there are positive ownership signals like a verified name or a linked GitHub repo.
+
+  LOW-DAA (avg_daa < max(chain_median_daa × 0.05, 3)):
+    → Private operator(s). DEXAggregator is invalid at this DAA level unless there is strong evidence the contract is a component of a known public aggregator. A contract that only performs price reads (slot0, getReserves) should be classified as `trading` (PriceScanner) by default.
+    → If success_rate < 90% AND DEX/swap activity → trading (MEVBot / ArbitrageBot).
+    → If success_rate ≥ 90% AND DEX/swap activity → trading (StrategyExecutor / [Protocol]Rebalancer).
+
+  MID-DAA (between LOW and HIGH thresholds):
+    → Examine caller_diversity_label and success_rate.
+    → KEEPER-ish + low success_rate + DEX swaps → trading (private strategy with rotating ops).
+    → PUBLIC-ish + high success_rate + diverse trace counterparties → dex / aggregator.
+    → When in doubt, prefer trading. DEXAggregator is a strong claim; require strong evidence.
+
+When picking the name "DEXAggregator", you MUST justify it by citing avg_daa ≥ chain_median_daa
+in the reasoning. If you cannot, use "StrategyExecutor" or "MEVBot" instead.
+
+### PATH G0 — No Caller Data
+IF caller_diversity_label = "UNKNOWN":
+  **ONLY use this path if the data literally says "Caller diversity label: UNKNOWN". If it says PRIVATE, KEEPER, or PUBLIC — use G1, G2, or G3 instead, regardless of trace quality.**
+  UNKNOWN means caller sampling failed — a data gap. Without caller data, use available signals carefully.
+  → Decision tree:
+  1. IF `github.has_valid_repo=true`: This contract has confirmed identity but no on-chain activity was observed. Classify as `developer_tools` with the name `UnusedProtocolComponent`.
+  2. Non-trading events (bridge, NFT transfers, governance, staking) → classify by those signals
+  3. success_rate clearly < 30% → near-certain MEV → trading, "MEVBot"
+  4. Named protocol interactions in traces that imply a specific non-trading purpose → classify accordingly
+  5. txcount > 300k AND all_trace_call_graphs_empty=True AND no events AND no meaningful identity
+     → high-volume unidentifiable contract; lean trading, "StrategyExecutor"
+     BUT: if DAA/tx signal says BROAD USER BASE (>5%) → override to other (public-facing, not a bot)
+  6. IF all_traces_empty=True AND novel_tokens contains multiple memecoin-like names → trading, "SniperBot".
+  7. IF all_traces_empty=True AND novel_tokens or bs_token_transfers contains a pair of common DeFi tokens (e.g., WETH, USDC) → lean trading, name based on the pair, e.g., "WETH-USDC-LPManager".
+  8. All else → other, "AmbiguousContract"
+  Note: DAA/tx=0.00% often means missing data, not confirmed automation — do not treat as strong trading signal alone.
+
+---
+
+## contract_name (max 50 chars)
+Name what the contract IS or DOES — use protocol-aware names when traces reveal them.
+
+Naming source priority (high to low):
+1. Specific naming patterns from the matched DECISION PATH (e.g., '[Protocol]CLRebalancer' from PATH G1) override all other naming sources. You MUST use these when their criteria are met.
+2. Verified Blockscout name (PATH A) or delegate-target name (PATH B).
+3. Protocol name from `github.has_valid_repo=true`. Use it as a prefix, e.g., '[Protocol]Escrow'.
+4. Named contracts in traces — `named_contracts_in_traces` is the strongest external-identity signal. Build descriptive names from these: "[Protocol]Manager", "[Protocol]Adapter".
+   Exception for LP Rebalancers: If behavior is clearly LP management (slot0 reads, mint/burn/collect) AND a major stablecoin (USDC/USDT/DAI/FiatToken) is present, you MUST prioritize the stablecoin for naming (e.g., 'FiatTokenCLRebalancer').
+5. Novel-protocol tokens (`novel_tokens` list) — only when traces lack named protocol contracts. When multiple tokens are present, prioritize the non-stablecoin or protocol-specific token.
+6. Behavioral name from caller pattern or trace function calls — "MEVBot", "ArbitrageBot", "PriceScanner", "StrategyExecutor". If you see function names describing specific actions on an object (e.g., `equipItem`, `mintCharacter`), prefer a role-based name like `ItemManager` or `CharacterFactory`.
+
+Constraints:
+- **Hierarchy is strict**: Prioritize `named_contracts_in_traces` over `novel_tokens` or `bs_token_transfers`.
+- **Forbid composites**: Do not fuse signals from different priority levels. Examples:
+  "UAVPoolManager" (UAV from token + PoolManager from trace) is WRONG. Pick one source.
+  "BasedPepePriceScanner" (token + behavior) is WRONG. For unverified trading contracts, prioritize the behavioral name ('PriceScanner', 'StrategyExecutor') over a name derived from a novel token.
+  "SwapRouterStrategyExecutor" (traced contract + behavior) is WRONG. Derive a descriptive name like 'SwapRouterManager' instead.
+- **Private Trading Bots (PATH G1/G2)**: The behavioral name ('StrategyExecutor', 'MEVBot') is the primary identity. Do NOT prepend token names. The presence of novel tokens indicates assets being traded, not the bot's identity.
+- **Generic Names**: If a verified name is a generic implementation (ERC20, ERC721, ERC1967Proxy, StandardToken), it is uninformative. Derive the real name from the token in `bs_token_transfers` (e.g. "Autonolas" not "OptimismMintableERC20").
+- **Unverified trading contracts**: Describe the behavior — "MEVBot", "ArbitrageBot", "PriceScanner". Only use specific names like 'PriceScanner' or 'MEVBot' when strict criteria (PATH F, low success_rate) are met. Otherwise, default to "StrategyExecutor". The names '[Protocol]CLRebalancer' and '[Protocol][Token]LPManager' MUST only be used with explicit trace evidence of LP/gauge interaction.
+- **Unverified non-trading**: derive from trace interactions — "OracleConsumer", "DEXAggregator", "BridgeCaller".
+- **PATH E (EIP-1167 clones, empty trace)**: name "CloneExecutor" by default — do not say "StrategyExecutor" unless the caller pattern matches G1.
+- **Use "AmbiguousContract"** ONLY when bs_name=unknown AND novel_tokens=empty AND named_contracts_in_traces=empty AND log_signals all false. Otherwise produce a descriptive name.
+- **NEVER use generic filler**: "UnverifiedProxy", "UnverifiedContract", "Unknown", "MinimalProxy".
+
+---
+
+NOTE — Event signals are strong type indicators. A contract emitting Swap events IS a DEX pool.
+AccessControl events alone = permissioned infrastructure, NOT a bot. Use AccessControl to confirm or upgrade confidence, not as a primary classifier.
+
+For the reasoning field — required format: "PATH X[subpath]: [key signal=val, signal=val] → [chosen category]. Ruled out [alt] because [reason]."
+Examples:
+  "PATH G1: diversity=PRIVATE, success=99.9%, AccessControl, no swap events → trading. Ruled out dex (no pool calls)."
+  "PATH C: router_calls=[SwapRouter02], DAA/tx=0.3%, success=18% → trading/MEVBot. Ruled out dex (above router stack)."
+  "PATH A: verified=True, name=GridMining, VRF calls in trace → gaming. Ruled out other (name is specific)."
+No filler, no articles, fragments OK. Always name the path. Always name what was ruled out.

--- a/backend/labeling/prompts/v1.md
+++ b/backend/labeling/prompts/v1.md
@@ -1,0 +1,321 @@
+You are a smart contract protocol analyst. Classify the contract described below by following the decision paths IN ORDER. Stop at the first path that applies.
+
+## is_protocol_contract_likely
+Set to `true` ONLY when there is strong evidence of ownership or public infrastructure: `github.has_valid_repo=true`, a verified name from a known protocol, or high public usage (HIGH-DAA). Do NOT set to `true` for unverified, private-caller contracts based solely on token interactions (`novel_tokens`). Contracts classified as `trading` under PATH G1 or G2 MUST have `protocol_likely=false`, as they are private bots by definition.
+
+## HOW TO CLASSIFY
+
+Three primary sources of truth, in order of reliability:
+1. **Verified name** — if the contract is source-verified with a real name, read it as a human would. "GridMining" is gaming. "LendingPool" is lending. "BridgeRouter" is bridge. Trust your semantic understanding of what the name describes. Use traces to confirm or disambiguate, not to override.
+2. **Trace behavior** — what the contract actually does: what it calls, what events it emits, what state it changes. Classify by function.
+3. **GitHub repository** — if `github.has_valid_repo=true`, the linked repo is a strong identity + ownership signal. Treat it like verification: do NOT default such a contract to trading/MEV in PATH G1/G2/G3 — classify by trace content or name semantics instead.
+
+Numerical signals (success_rate, DAA/tx, rel_cost) are tiebreakers in most cases. They shift
+confidence but do not override clear semantic or trace evidence.
+
+**Exception — avg_daa is a primary signal for public/private classification.**
+A contract with avg_daa ≥ chain_median_daa is public infrastructure by definition (real users from
+many addresses). It cannot be a private trading bot regardless of trace shape. Conversely, a contract
+with avg_daa far below chain_median (single-digit DAA on a chain whose median is hundreds) is a
+private operator, and "DEXAggregator" / "DEX" labels are invalid for it without strong evidence
+that the few callers are real public EOAs (not admin keepers cycling addresses). See the
+"avg_daa Discriminator" section below.
+
+**Output discipline.** The `reasoning` field MUST end with `→ <category>` and that category MUST equal the `usage_category` field. Never conclude `→ trading` (or oracle / bridge / etc.) and then output `usage_category="other"`. If you cannot pick a specific category from the path, conclude `→ other` explicitly.
+
+## DECISION PATHS (follow in order, stop at first match)
+
+### PATH -1 — Zero-Transaction Gate
+IF `txcount` = 0: This contract has never executed. All trace and log signals will be empty. Classify as `other` with name `UnexecutedContract` and low confidence. Stop here.
+
+### PATH 0 — Identity Gate  (RUN FIRST, ALWAYS)
+Before evaluating any other path, evaluate identity:
+
+  IF source_verified=True OR github.has_valid_repo=true:
+    → This contract has confirmed protocol identity. You MUST classify by trace content,
+      verified name, or repository ownership. PATH G1 / G2 / G3 trading defaults DO NOT apply.
+      "PRIVATE callers" alone is NOT grounds for `trading` when identity is confirmed.
+    → Proceed to PATH A (verified) or PATH B (proxy) and continue down the list.
+    → Exception: confirmed-identity contracts whose dominant trace activity is automated LP
+      management (CLPool/CLGauge/NonfungiblePositionManager mint/burn/collect) ARE `trading`,
+      even with confirmed identity. This single exception applies — no other identity-confirmed
+      contract may be classified `trading` based on caller diversity alone.
+    → When `github.has_valid_repo=true`, the linked repository's organization is a strong owner-project signal. You MUST use this to assert `protocol_likely=true` and name the owner project in your reasoning. The repository's identity is a primary classification signal; if the repo name implies a function (e.g., 'ultron-bridge'), use that to determine the category, overriding weaker trace signals.
+
+  IF source_verified=False AND github.has_valid_repo=False:
+    → No confirmed identity. PATH G1 / G2 / G3 caller-based trading defaults apply normally.
+
+### PATH A — Verified + Named Contract
+IF source_verified=True AND blockscout_name != "unknown":
+  → contract_name = exact Blockscout name
+  → Classify by the semantic meaning of the verified name. Read it as a human — you know what protocols do.
+  → Sanity Check: If the name implies a function (e.g., 'Bridge') but all corresponding trace/log signals are negative (`log_has_bridge_events=false`), the name may be misleading; re-evaluate based on other signals.
+  → Use traces to disambiguate when the name alone is genuinely unclear. VRF calls (Chainlink VRF, Pyth) → gaming. NFT interactions without marketplace → gaming or non_fungible_tokens. If `traces_only_raw_opcodes=true`, state that the trace is uninformative; do not invent function calls.
+  → When trace signals are absent because `all_traces_empty=true`, the semantic meaning of the verified name is the sole, authoritative signal. Trust it completely.
+  → The verified name overrides MEV/bot heuristics — do NOT reclassify a named protocol as trading because callers are private or success_rate is low.
+  → Protocol-specific corrections (the name sounds like X but IS actually Y):
+      Permit2, Permit3, AllowanceHolder → developer_tools  (approval middleware, not a DEX router)
+      GPv2Settlement, CoWSwap*, CowSwap*, BatchSettlement → dex  (batch DEX settlement, not a trading bot)
+      Relay*Router, RelayRouter, RelayBridge, RelayReceiver, RelayDepository → bridge
+      Rango*, RangoDiamond → bridge  (bridge aggregator, not dex)
+      *DVN, *Dvn → cc_communication  (LayerZero verifier network)
+      MayanSwift*, Mayan*Bridge → bridge
+      Socket*, SocketGateway, SocketBridge → bridge
+      OffchainAggregator, AccessControlledOffchainAggregator, *EACAggregator*, BlockhashStore → oracle  (Chainlink data feed or utility)
+      OpenOceanSwapModule, OpenOcean*Module → nft_marketplace  (Seaport-bound; classify by host protocol)
+      ConditionalTokens, CTFExchange, NegRiskAdapter → prediction_markets  (Polymarket / Omen pattern)
+      IdRegistry, NameRegistry, *Registrar (Farcaster, ENS, Lens) → identity
+      *Factory, *Deployer, *Creator (deploys other contracts via CREATE/CREATE2) → developer_tools
+        (the factory's role is deployment infra; do not inherit category from what it deploys)
+      TransparentUpgradeableProxy, ERC1967Proxy, ProxyAdmin (when bs_name is exactly that) → developer_tools
+      *Router without clear DEX context → examine trace, do NOT default to dex
+      *FeeForwarder, *FeeProvider, *FeeCollector, *FeeDistributor → payments
+      BatchResolver → gaming
+  → Airdrop/Distribution patterns: If the name contains keywords like Airdrop, Claim, Distributor, Vesting, Launcher, Rewards, or Points, classify as `airdrop`. This pattern overrides a simple token-name match.
+  → Stablecoin token check (W6): if the contract name is a distribution/claim mechanism
+    (Claim, DiamondClaim, Distributor, Airdrop, Vesting) AND traces show transfers of known
+    stablecoin tokens (Tether, TetherToken, USDT, USDC, FiatToken, DAI, BUSD, TUSD, or any
+    token name containing "USD" or "Stablecoin") → stablecoin, NOT fungible_tokens.
+
+### PATH B — Proxy Delegating to Named Implementation
+IF the signal "this contract itself delegates to (named)" is non-null and contains a resolved contract name:
+  → This proxy IS that named implementation. Classify by what the delegate target does.
+  → CLPool / UniswapV3Pool / PancakeV3Pool → dex
+  → EntryPoint → erc4337
+  → FiatToken / USDC / ERC20 → stablecoin or fungible_tokens
+  → RangoDiamond, Rango* → bridge
+  → Relay*Router, RelayRouter* → bridge
+  → Endpoint, EndpointV2, LZEndpoint → bridge (LayerZero endpoint proxy)
+  → Apply same protocol-specific corrections from PATH A for any ambiguous delegate names
+  NOTE (W5): Generic proxy names (TransparentUpgradeableProxy, OptimizedTransparentUpgradeableProxy,
+  ERC1967Proxy, etc.) are stripped before reaching this path — they are treated as "unknown" name.
+  The DELEGATECALL target name IS available in traces as "this contract itself delegates to".
+  Always prefer the delegate target name over the proxy wrapper name.
+
+### PATH C — Calls Official DEX Router (depth ≤1)
+IF "Direct calls into official DEX routers" list is non-empty:
+  → This contract is ABOVE official routers in the stack — an aggregator, bot, or strategy
+  EXCEPTION — verified contracts: do NOT apply the trading default.
+    Verified contracts that call official routers are settlement/fulfillment infrastructure
+    (RFQ market makers, solver contracts, intent-settlement). Prefer dex.
+    Only assign trading if traces show explicit MEV patterns (very low success_rate + clear failed-tx-heavy volume).
+  → Unverified contracts: default to trading unless strong evidence of a public aggregator:
+    - Few unique callers (low DAA/tx) → trading
+    - Many failed txs (low success_rate) → trading, lean high confidence
+    - High DAA/tx + high success_rate → could be public aggregator → dex
+    - Both low DAA/tx AND low success_rate → near-certain private trading
+
+### PATH D — Calls AMM Pool Swap Functions Directly (depth ≤1)
+IF "Direct calls into AMM pool swap functions" = True AND no_meaningful_identity = True:
+  → Calls CLPool.swap / UniswapV3Pool.swap directly (not just price reads)
+  NOTE: AMM pools list non-empty but swap = False → price reads only (slot0, getReserves). Do not use PATH D; fall through to PATH F or G.
+  → PRIMARY: caller pattern — PRIVATE callers → trading; DIVERSE callers → dex
+  → SECONDARY: success_rate < 50% → aggressive bot → trading; ≥70% + diverse → dex
+  → TERTIARY (no caller data): low DAA/tx → trading; high DAA/tx → dex
+
+### PATH E — EIP-1167 Minimal Clone (Empty Trace)
+IF "this contract has raw-address DELEGATE" = True AND "all trace call graphs empty" = True:
+  → Factory clone forwarding to unresolvable implementation
+  → PRIVATE callers → trading executor; DIVERSE callers → dex infrastructure clone
+  → Use txcount as a tiebreaker when caller data is unavailable: high volume → trading, low → dex
+  → Confidence is inherently limited — cannot fully resolve without the implementation
+
+### PATH F — Pure Price Scanner
+IF trace contains ONLY STATICCALL/SLOAD ops AND calls are exclusively slot0/price-read functions
+   (slot0, observe, getReserves, latestRoundData) across multiple pools AND no swap/transfer calls:
+  → Hunts opportunities without executing — Searcher or PriceScanner
+  → usage_category = trading
+  → Distinguish from oracle consumers: oracle consumers call Chainlink feeds (EACAggregatorProxy);
+    Searchers call AMM pool slot0 across many different pools to compare prices
+
+### PATH O — Oracle Infrastructure
+IF "Oracle function calls detected" list is non-empty AND those functions are central
+   (entry method OR matched in the majority of traces):
+  → Oracle-specific functions: storkPublicKey, latestRoundData, latestAnswer, updatePriceFeed,
+    updatePrices, postPrices, parsePriceFeedUpdates, transmit, fulfillOracleRequest, fulfillOracleRequest2.
+    A contract whose entry method is updatePrices/updatePriceFeed is an oracle pusher — classify oracle
+    even when callers are PRIVATE (single operator) or PUBLIC (decentralized network).
+  → usage_category = oracle  (this is sticky — once chosen, do not fall back to "other" later in reasoning)
+  → Name: "[Protocol]Oracle", "[Protocol]PriceFeed", or "[Protocol]OracleProxy" depending on trace depth.
+    If DELEGATECALL to oracle → it IS the oracle (proxy). If CALL → it USES the oracle (consumer).
+    Chainlink Operator contracts (calling fulfillOracleRequest/transmit) are oracle, not their host protocol.
+  → Override for unverified contracts with PRIVATE callers — a single-operator oracle updater
+    is still oracle infrastructure, not a trading bot.
+  → Soft exception: if a contract calls one oracle getter incidentally (e.g. latestAnswer once)
+    but the dominant activity is large stablecoin transfers or DEX swaps, classify by the dominant
+    activity instead. Do not treat one oracle getter as conclusive evidence of oracle identity.
+
+### PATH G1 — Private Callers (PRIVATE diversity ≤20%)
+IF caller_diversity_label = "PRIVATE" AND no prior path matched:
+  **STOP: First, check `source_verified` and `github.has_valid_repo`. If either is true, you MUST follow the 'EXCEPTION' logic below. Do not proceed to the 'Unverified private callers' section.**
+  **CRITICAL: This path applies even when traces are raw opcodes only and identity is unknown.
+  Raw-opcode traces + PRIVATE callers + no identity IS the trading bot signature — intentionally unverified.
+  Do NOT skip to G0 because traces are unreadable. If the label says PRIVATE, use G1.**
+  EXCEPTION — verified contracts OR `github.has_valid_repo=true`: do NOT apply trading defaults.
+    Contracts with confirmed identity (verified source OR linked GitHub repo) and private callers
+    are almost always protocol infrastructure (vault, liquidator, position manager), not MEV bots.
+    For example, a contract interacting with another contract named 'Rewards' or distributing a protocol's own token is likely `staking` or `airdrop` infrastructure, not `trading`.
+    Classify by trace content; only assign trading if traces explicitly show MEV patterns (raw slot0
+    reads across many pools, failed-tx-heavy swaps).
+  EXCEPTION-TO-EXCEPTION: verified or github-linked contracts that interact directly with
+    LP infrastructure (CLPool/CLGauge/NonfungiblePositionManager, Aerodrome/Velodrome rebalancers)
+    via mint/burn/collect/_collect calls ARE automated trading strategies, not protocol infra.
+    Classify trading even when verified. Name "[Protocol]Rebalancer" or "[Asset]PositionManager"
+    using the underlying-asset rule from §contract_name.
+  VERIFIED + DEX router calls: prefer dex — settlement or fulfillment infrastructure. Use trace entry
+    function to name it (e.g. "RFQSettlement", "FulfillHelper"). Exception: very low success_rate or
+    clear failed-tx patterns → trading still possible.
+  VERIFIED + bridge calls: prefer bridge or cc_communication.
+  → Unverified private callers: TRADING IS THE ONLY VALID CLASSIFICATION. Do not use other.
+    EXCEPTION for low activity: If txcount < 5 AND avg_daa < 1, this is likely a test or deployment artifact, not an active bot. Classify as `other` with the name `LowActivityContract` and stop.
+    A single operator running automated on-chain transactions is by definition a trading bot.
+    Unverified bots intentionally leave no decoded traces — raw opcodes and no identity ARE the signal.
+    "No specific trading signals" is not a valid reason to pick other over trading here.
+    These contracts MUST have `is_protocol_contract_likely=false`.
+    Name it based on available signals, but the category is always trading:
+  - LP/gauge contracts (CLGauge, CLPool, NonfungiblePositionManager) + novel tokens in traces:
+      ACTIVE REBALANCER (slot0 reads + _collect + burns/mints in same tx) → trading, "[Protocol]CLRebalancer"
+      PASSIVE LP MANAGER (only deposit/withdraw/mint/burn, no slot0 reads) → trading, "[Protocol][Token]LPManager"
+      Include token pair in name when identifiable.
+  - Very low success_rate → near-certain MEV/arbitrage → trading, "MEVBot" or "ArbitrageBot"
+  - High success_rate → efficient strategy → trading, "StrategyExecutor"
+  - Raw opcodes only, no decoded calls → trading, "StrategyExecutor"
+  - Truly undifferentiated (no useful signals at all) → trading, "StrategyExecutor"
+  - AccessControl events: confirms permissioned automation, does NOT change category
+
+### PATH G2 — Keeper Callers (KEEPER diversity 20–80%)
+IF caller_diversity_label = "KEEPER" AND no prior path matched:
+  EXCEPTION — verified contracts with named protocol interactions: classify by trace content.
+    Verified keeper contracts are typically protocol infrastructure (liquidators, settlement, distributors).
+    If a verified contract is a proxy delegating to an unverified implementation (raw_delegate=true) and its traces consist only of raw opcodes, its function is ambiguous. Classify as `other` and name it `VerifiedProxyToUnknownImpl`.
+  EXCEPTION-TO-EXCEPTION: verified contracts whose dominant trace activity is automated LP
+    management (CLPool/CLGauge/NonfungiblePositionManager mint/burn/collect) ARE trading.
+  VERIFIED + DEX router calls: KEEPER + verified + DEX router = DEX settlement/aggregation signature
+    (1inch resolvers, CoW solvers, RFQ market makers are all KEEPER callers). Prefer dex.
+  VERIFIED + bridge calls: prefer bridge or cc_communication.
+  → Unverified multi-operator permissioned system. Check explicit protocol signals FIRST before
+    defaulting to trading. Apply these overrides in order even when unverified:
+  1. Interactions with known DEX infrastructure (`named_contracts_in_traces` contains SwapRouter, UniswapV3Pool) → dex.
+  2. "Direct calls into lending protocols" non-empty (Aave, Compound, Morpho, etc.)
+     AND no slot0/price-read pattern → lending (or derivative for perp protocols)
+     Name: "[Protocol]Liquidator" or "[Protocol]KeeperBot"
+  3. "Direct calls into bridge protocols" non-empty (Stargate, LayerZero, Connext, etc.)
+     OR bridge events (MessagePassed, SentMessage, PacketSent) → bridge or cc_communication
+  4. ERC-4337 events (UserOperationEvent, AccountDeployed) → erc4337
+  5. Governance events (ProposalCreated, VoteCast) → governance
+  → After checking the above, if no protocol signal matched:
+  If traces are raw opcodes only with no identity and KEEPER callers, the contract's function is ambiguous. If there are absolutely no other DeFi signals (swaps, lending, LP management), classify as `other` with name `AmbiguousExecutor`. If DeFi signals are present but un-decoded, `trading` with name `StrategyExecutor` is a reasonable fallback.
+  - LP/gauge contracts + novel tokens: same ACTIVE/PASSIVE rebalancer distinction as G1
+  - AccessControl events + no identifiable protocol interactions → trading executor
+  - Known non-trading protocol interactions in traces: classify by what it interacts with
+  - No DeFi signals, specific name: classify by semantic meaning of name. Do NOT default to other.
+  - Truly unclear: use trading as fallback, "StrategyExecutor"
+
+### PATH G3 — Public Callers (PUBLIC diversity ≥80%)
+IF caller_diversity_label = "PUBLIC" AND no prior path matched:
+  → Many different callers — public-facing. Classify by what the contract does.
+  - **Stablecoin name match**: novel_tokens or bs_token_transfers token name/symbol contains
+    USD / Stable / DAI / USDT / USDC / USDM / BUSD / TUSD / FRAX / LUSD AND that token is the
+    primary asset moved. This is a strong signal, but must be confirmed by contract function. Classify as `stablecoin` only when the contract's primary role is distribution (Airdrop, Vesting), minting, or redemption of the stablecoin itself. If traces suggest yield, lending, or staking activity, prefer that category.
+  - **Low success_rate override**: success_rate < 60% with DEX router or pool-swap traces →
+    public arbitrage / sandwich pattern → trading, "MEVBot" or "ArbitrageBot". Many public callers
+    competing and failing is the MEV signature; do NOT classify as dex when most txs revert.
+  - Known DEX interactions (swap events, pool calls) AND success_rate ≥ 60% AND avg_daa qualifies
+    as PUBLIC (see §avg_daa Discriminator below) → dex
+  - Named STATIC calls to EACAggregatorProxy/Chainlink feeds → oracle consumer
+  - Pool-internal math (computeSwapStep, getSqrtRatioAtTick as INTERNAL nodes) → dex
+  - Calls to LayerZero, Wormhole, Axelar, or other cross-chain messaging endpoints → cc_communication
+  - Calls to Relay*, Stargate, Connext, Synapse, Across, deBridge → bridge
+  - Calls to VRF (Chainlink VRF, Pyth randomness) → gaming
+  - Airdrop/Claim/Distributor/Vesting/Rewards/Points patterns with broad user base AND
+    no stablecoin-name match above → airdrop
+  - Stablecoin distribution (FiatToken/USDC/Tether transfers via Claim/Airdrop/Vesting patterns) → stablecoin
+  - Social/check-in pattern (simple state writes per user, no DeFi signals) → community
+  - Calls to `liquidate`, `auction`, `seize`, or `settle` on lending/perp contracts → lending or derivative
+  - No DeFi signals: classify by semantic meaning of the contract name. Do NOT default to other for a specific name.
+  - Truly ambiguous name AND no usable signals → other
+  - IMPORTANT: Named contracts in the DEEP trace are downstream callees — do NOT classify this contract as CLPool just because CLPool appears in the trace.
+
+### avg_daa Discriminator — Trading vs DEXAggregator
+CRITICAL: These DAA gates are mandatory checks that MUST be performed before assigning the `dex` category to any unverified contract in PATH C, D, or G. Your reasoning must explicitly state which DAA tier the contract falls into.
+
+The single strongest signal separating private trading bots from public DEX infrastructure is
+**absolute avg_daa relative to chain_median_daa**. Apply these gates BEFORE picking dex/DEXAggregator:
+
+  HIGH-DAA (avg_daa ≥ chain_median_daa AND avg_daa ≥ 50):
+    → Public infrastructure. Many independent users. Cannot be a private trading bot regardless
+       of how trading-shaped the traces look. Even if the contract calls DEX routers and swaps
+       look bot-like, high public usage rules out trading. Classify dex / bridge / oracle / etc.
+       by trace content. Override "trading bot" heuristics from G1/G2.
+    → Note: 'Public infrastructure' does not automatically mean `protocol_likely=true`. Only assert `protocol_likely=true` if there are positive ownership signals like a verified name or a linked GitHub repo.
+
+  LOW-DAA (avg_daa < max(chain_median_daa × 0.05, 3)):
+    → Private operator(s). DEXAggregator is invalid at this DAA level unless there is strong evidence the contract is a component of a known public aggregator. A contract that only performs price reads (slot0, getReserves) should be classified as `trading` (PriceScanner) by default.
+    → If success_rate < 90% AND DEX/swap activity → trading (MEVBot / ArbitrageBot).
+    → If success_rate ≥ 90% AND DEX/swap activity → trading (StrategyExecutor / [Protocol]Rebalancer).
+
+  MID-DAA (between LOW and HIGH thresholds):
+    → Examine caller_diversity_label and success_rate.
+    → KEEPER-ish + low success_rate + DEX swaps → trading (private strategy with rotating ops).
+    → PUBLIC-ish + high success_rate + diverse trace counterparties → dex / aggregator.
+    → When in doubt, prefer trading. DEXAggregator is a strong claim; require strong evidence.
+
+When picking the name "DEXAggregator", you MUST justify it by citing avg_daa ≥ chain_median_daa
+in the reasoning. If you cannot, use "StrategyExecutor" or "MEVBot" instead.
+
+### PATH G0 — No Caller Data
+IF caller_diversity_label = "UNKNOWN":
+  **ONLY use this path if the data literally says "Caller diversity label: UNKNOWN". If it says PRIVATE, KEEPER, or PUBLIC — use G1, G2, or G3 instead, regardless of trace quality.**
+  UNKNOWN means caller sampling failed — a data gap. Without caller data, use available signals carefully.
+  → Decision tree:
+  1. IF `github.has_valid_repo=true`: This contract has confirmed identity but no on-chain activity was observed. Classify as `developer_tools` with the name `UnusedProtocolComponent`.
+  2. Non-trading events (bridge, NFT transfers, governance, staking) → classify by those signals
+  3. success_rate clearly < 30% → near-certain MEV → trading, "MEVBot"
+  4. Named protocol interactions in traces that imply a specific non-trading purpose → classify accordingly
+  5. txcount > 300k AND all_trace_call_graphs_empty=True AND no events AND no meaningful identity
+     → high-volume unidentifiable contract; lean trading, "StrategyExecutor"
+     BUT: if DAA/tx signal says BROAD USER BASE (>5%) → override to other (public-facing, not a bot)
+  6. IF all_traces_empty=True AND novel_tokens contains multiple memecoin-like names → trading, "SniperBot".
+  7. IF all_traces_empty=True AND novel_tokens or bs_token_transfers contains a pair of common DeFi tokens (e.g., WETH, USDC) → lean trading, name based on the pair, e.g., "WETH-USDC-LPManager".
+  8. All else → other, "AmbiguousContract"
+  Note: DAA/tx=0.00% often means missing data, not confirmed automation — do not treat as strong trading signal alone.
+
+---
+
+## contract_name (max 50 chars)
+Name what the contract IS or DOES — use protocol-aware names when traces reveal them.
+
+Naming source priority (high to low):
+1. Specific naming patterns from the matched DECISION PATH (e.g., '[Protocol]CLRebalancer' from PATH G1) override all other naming sources. You MUST use these when their criteria are met.
+2. Verified Blockscout name (PATH A) or delegate-target name (PATH B).
+3. Protocol name from `github.has_valid_repo=true`. Use it as a prefix, e.g., '[Protocol]Escrow'.
+4. Named contracts in traces — `named_contracts_in_traces` is the strongest external-identity signal. Build descriptive names from these: "[Protocol]Manager", "[Protocol]Adapter".
+   Exception for LP Rebalancers: If behavior is clearly LP management (slot0 reads, mint/burn/collect) AND a major stablecoin (USDC/USDT/DAI/FiatToken) is present, you MUST prioritize the stablecoin for naming (e.g., 'FiatTokenCLRebalancer').
+5. Novel-protocol tokens (`novel_tokens` list) — only when traces lack named protocol contracts. When multiple tokens are present, prioritize the non-stablecoin or protocol-specific token.
+6. Behavioral name from caller pattern or trace function calls — "MEVBot", "ArbitrageBot", "PriceScanner", "StrategyExecutor". If you see function names describing specific actions on an object (e.g., `equipItem`, `mintCharacter`), prefer a role-based name like `ItemManager` or `CharacterFactory`.
+
+Constraints:
+- **Hierarchy is strict**: Prioritize `named_contracts_in_traces` over `novel_tokens` or `bs_token_transfers`.
+- **Forbid composites**: Do not fuse signals from different priority levels. Examples:
+  "UAVPoolManager" (UAV from token + PoolManager from trace) is WRONG. Pick one source.
+  "BasedPepePriceScanner" (token + behavior) is WRONG. For unverified trading contracts, prioritize the behavioral name ('PriceScanner', 'StrategyExecutor') over a name derived from a novel token.
+  "SwapRouterStrategyExecutor" (traced contract + behavior) is WRONG. Derive a descriptive name like 'SwapRouterManager' instead.
+- **Private Trading Bots (PATH G1/G2)**: The behavioral name ('StrategyExecutor', 'MEVBot') is the primary identity. Do NOT prepend token names. The presence of novel tokens indicates assets being traded, not the bot's identity.
+- **Generic Names**: If a verified name is a generic implementation (ERC20, ERC721, ERC1967Proxy, StandardToken), it is uninformative. Derive the real name from the token in `bs_token_transfers` (e.g. "Autonolas" not "OptimismMintableERC20").
+- **Unverified trading contracts**: Describe the behavior — "MEVBot", "ArbitrageBot", "PriceScanner". Only use specific names like 'PriceScanner' or 'MEVBot' when strict criteria (PATH F, low success_rate) are met. Otherwise, default to "StrategyExecutor". The names '[Protocol]CLRebalancer' and '[Protocol][Token]LPManager' MUST only be used with explicit trace evidence of LP/gauge interaction.
+- **Unverified non-trading**: derive from trace interactions — "OracleConsumer", "DEXAggregator", "BridgeCaller".
+- **PATH E (EIP-1167 clones, empty trace)**: name "CloneExecutor" by default — do not say "StrategyExecutor" unless the caller pattern matches G1.
+- **Use "AmbiguousContract"** ONLY when bs_name=unknown AND novel_tokens=empty AND named_contracts_in_traces=empty AND log_signals all false. Otherwise produce a descriptive name.
+- **NEVER use generic filler**: "UnverifiedProxy", "UnverifiedContract", "Unknown", "MinimalProxy".
+
+---
+
+NOTE — Event signals are strong type indicators. A contract emitting Swap events IS a DEX pool.
+AccessControl events alone = permissioned infrastructure, NOT a bot. Use AccessControl to confirm or upgrade confidence, not as a primary classifier.
+
+For the reasoning field — required format: "PATH X[subpath]: [key signal=val, signal=val] → [chosen category]. Ruled out [alt] because [reason]."
+Examples:
+  "PATH G1: diversity=PRIVATE, success=99.9%, AccessControl, no swap events → trading. Ruled out dex (no pool calls)."
+  "PATH C: router_calls=[SwapRouter02], DAA/tx=0.3%, success=18% → trading/MEVBot. Ruled out dex (above router stack)."
+  "PATH A: verified=True, name=GridMining, VRF calls in trace → gaming. Ruled out other (name is specific)."
+No filler, no articles, fragments OK. Always name the path. Always name what was ruled out.

--- a/backend/labeling/prompts/versions.json
+++ b/backend/labeling/prompts/versions.json
@@ -1,0 +1,16 @@
+{
+  "current": "v1",
+  "history": [
+    {
+      "version": "v1",
+      "run_id": "2026-05-19_v1",
+      "deployed_at": "2026-05-26T10:07:06.803466+00:00",
+      "lines": 321,
+      "accuracy": {
+        "category_new": "16/31 (51.6%)",
+        "wins_regressions": "Wins** (wrong\u2192right): 16  |  **Regressions** (right\u2192wrong): 0",
+        "name_exact_new": "9/45 (20.0%)"
+      }
+    }
+  ]
+}

--- a/backend/misc/backfill_label_review.py
+++ b/backend/misc/backfill_label_review.py
@@ -1,0 +1,186 @@
+"""
+Backfill contract_label_review from verified GTP attester labels.
+
+Joins contract_label_features (AI baseline) against public.labels
+(GTP attester pivot) and inserts diff rows into contract_label_review.
+
+Safe to re-run — skips (address, origin_key) pairs already present.
+
+Usage:
+    python backend/misc/backfill_label_review.py [--dry-run]
+"""
+import sys, os, argparse
+from pathlib import Path
+
+_BACKEND = Path(__file__).parent.parent
+sys.path.insert(0, str(_BACKEND))
+os.chdir(_BACKEND)
+
+from dotenv import load_dotenv
+load_dotenv(dotenv_path=_BACKEND / ".env", override=False)
+load_dotenv(dotenv_path=_BACKEND.parent / ".env", override=False)
+
+import pandas as pd
+from sqlalchemy import text
+from src.db_connector import DbConnector
+
+GTP_ATTESTER = 'A725646C05E6BB813D98C5ABB4E72DF4BCF00B56'  # no 0x prefix for decode()
+
+PIVOT_SQL = text("""
+    WITH latest_labels AS (
+        -- labels.address is text ('0x'-prefixed lowercase hex), not bytea
+        SELECT
+            l.address,
+            l.chain_id,
+            MAX(CASE WHEN l.tag_id = 'contract_name'  THEN l.tag_value END) AS gtp_name,
+            MAX(CASE WHEN l.tag_id = 'usage_category' THEN l.tag_value END) AS gtp_cat,
+            MAX(CASE WHEN l.tag_id = 'owner_project'  THEN l.tag_value END) AS gtp_owner,
+            MAX(l.time) AS attested_at
+        FROM public.labels l
+        WHERE l.attester = decode(:attester, 'hex')
+        GROUP BY l.address, l.chain_id
+    ),
+    already_reviewed AS (
+        SELECT address, origin_key FROM public.contract_label_review
+    )
+    SELECT
+        '0x' || encode(f.address, 'hex')   AS address,
+        f.origin_key,
+        f.labeled_at,
+        ll.attested_at                      AS reviewed_at,
+        f.ai_contract_name,
+        f.ai_usage_category,
+        f.ai_confidence,
+        f.ai_owner_project_likely,
+        ll.gtp_name,
+        ll.gtp_cat,
+        ll.gtp_owner
+    FROM public.contract_label_features f
+    JOIN public.sys_main_conf s   ON s.origin_key = f.origin_key
+    JOIN latest_labels ll
+        ON ll.address   = '0x' || encode(f.address, 'hex')
+        AND ll.chain_id = s.caip2
+    LEFT JOIN already_reviewed ar
+        ON ar.address    = f.address
+        AND ar.origin_key = f.origin_key
+    WHERE ar.address IS NULL
+""")
+
+
+def build_review_rows(df: pd.DataFrame) -> list[dict]:
+    """Transform pivot DataFrame into insert-ready dicts for insert_contract_label_review."""
+    rows = []
+    for _, r in df.iterrows():
+        ai_name = r['ai_contract_name'] if pd.notna(r['ai_contract_name']) else None
+        ai_cat  = r['ai_usage_category'] if pd.notna(r['ai_usage_category']) else None
+        gtp_name  = r['gtp_name']  if pd.notna(r['gtp_name'])  else None
+        gtp_cat   = r['gtp_cat']   if pd.notna(r['gtp_cat'])   else None
+        gtp_owner = r['gtp_owner'] if pd.notna(r['gtp_owner']) else None
+
+        rows.append({
+            'address':               r['address'],
+            'origin_key':            r['origin_key'],
+            'labeled_at':            r['labeled_at'],
+            'reviewed_at':           r['reviewed_at'],
+            'review_source':         'labels_backfill',
+            'ai_contract_name':      ai_name,
+            'ai_usage_category':     ai_cat,
+            'ai_confidence':         float(r['ai_confidence']) if pd.notna(r['ai_confidence']) else None,
+            'ai_owner_project_likely': bool(r['ai_owner_project_likely']) if pd.notna(r['ai_owner_project_likely']) else None,
+            'gtp_contract_name':  gtp_name  if gtp_name  != ai_name else None,
+            'gtp_usage_category': gtp_cat   if gtp_cat   != ai_cat  else None,
+            'gtp_owner_project':  gtp_owner,
+            'gtp_no_owner_project': False,
+        })
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Print rows that would be inserted without writing')
+    args = parser.parse_args()
+
+    db = DbConnector()
+    with db.engine.begin() as conn:
+        df = pd.read_sql(PIVOT_SQL, conn, params={'attester': GTP_ATTESTER})
+
+    print(f"Found {len(df)} contracts with GTP labels + features baseline")
+    print(df[['address', 'origin_key', 'ai_usage_category', 'gtp_cat', 'gtp_name', 'ai_contract_name']].to_string())
+
+    rows = build_review_rows(df)
+
+    changed_name = sum(1 for r in rows if r['gtp_contract_name'] is not None)
+    changed_cat  = sum(1 for r in rows if r['gtp_usage_category'] is not None)
+    has_owner    = sum(1 for r in rows if r['gtp_owner_project'] is not None)
+    print(f"\nDiff summary:")
+    print(f"  name changed:     {changed_name}")
+    print(f"  category changed: {changed_cat}")
+    print(f"  owner assigned:   {has_owner}")
+
+    if args.dry_run:
+        print("\n[dry-run] No rows written.")
+        return
+
+    # insert_contract_label_review uses the sequence for id; db_backup lacks USAGE on
+    # the sequence, so we supply explicit ids via raw psycopg2 to avoid that permission.
+    import psycopg2, psycopg2.extras
+    engine_url = db.engine.url
+    raw = psycopg2.connect(
+        host=engine_url.host,
+        port=engine_url.port or 5432,
+        dbname=engine_url.database,
+        user=engine_url.username,
+        password=engine_url.password,
+    )
+    cur = raw.cursor()
+    cur.execute("SELECT COALESCE(MAX(id), 0) FROM public.contract_label_review")
+    next_id = cur.fetchone()[0] + 1
+
+    insert_sql = """
+        INSERT INTO public.contract_label_review (
+            id, address, origin_key, labeled_at, reviewed_at, review_source,
+            ai_contract_name, ai_usage_category, ai_confidence, ai_owner_project_likely,
+            gtp_contract_name, gtp_usage_category, gtp_owner_project, gtp_no_owner_project
+        ) VALUES (
+            %(id)s,
+            decode(%(address_hex)s, 'hex'),
+            %(origin_key)s, %(labeled_at)s, %(reviewed_at)s, %(review_source)s,
+            %(ai_contract_name)s, %(ai_usage_category)s, %(ai_confidence)s, %(ai_owner_project_likely)s,
+            %(gtp_contract_name)s, %(gtp_usage_category)s, %(gtp_owner_project)s, %(gtp_no_owner_project)s
+        )
+    """
+    params = []
+    for i, r in enumerate(rows):
+        addr = r['address']
+        # strip leading \x or 0x to get raw hex for decode()
+        if addr.startswith('0x') or addr.startswith('\\x'):
+            addr_hex = addr[2:]
+        else:
+            addr_hex = addr
+        params.append({
+            'id': next_id + i,
+            'address_hex': addr_hex,
+            'origin_key': r['origin_key'],
+            'labeled_at': r['labeled_at'],
+            'reviewed_at': r['reviewed_at'],
+            'review_source': r['review_source'],
+            'ai_contract_name': r['ai_contract_name'],
+            'ai_usage_category': r['ai_usage_category'],
+            'ai_confidence': r['ai_confidence'],
+            'ai_owner_project_likely': r['ai_owner_project_likely'],
+            'gtp_contract_name': r['gtp_contract_name'],
+            'gtp_usage_category': r['gtp_usage_category'],
+            'gtp_owner_project': r['gtp_owner_project'],
+            'gtp_no_owner_project': r['gtp_no_owner_project'],
+        })
+
+    psycopg2.extras.execute_batch(cur, insert_sql, params)
+    raw.commit()
+    raw.close()
+    n = len(params)
+    print(f"\nInserted {n} rows into contract_label_review.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## feat(labeling): RL-inspired classifier eval pipeline with versioned prompt management

  ### Summary
 
  Builds a complete self-critique eval loop for the Gemini classifier — critiques AI output against human corrections, synthesizes a
  better prompt, verifies improvement, and deploys with version tracking. Also fixes two correctness bugs in `_is_protocol_likely()`
  and a performance issue causing 54 DB connections per eval run.

  ---

  ### Eval pipeline (`backend/labeling/eval/`)

  **4-phase orchestrator** in `eval_human_corrections.py`:

  - **Phase 1 — Critique**: loads `contract_label_features` + `contract_label_review`, runs per-row Gemini Pro meta-eval, writes
  `per_row.jsonl` + `report.md` with ranked error proposals. Zero enrichment cost.
  - **Phase 2 — Synthesize**: aggregates proposals via `prompt_synthesizer.py`, makes one Pro call, writes `candidate_prompt.md` +
  changelog. Proposals require `confidence >= 0.6 AND count >= 2` OR `confidence >= 0.85`.
  - **Phase 3 — Verify**: re-enriches via `context_cache.py` (Blockscout/Tenderly/GitHub, cached), reclassifies with Flash, writes
  `accuracy_report.md` — category/name/owner accuracy before vs after, confusion matrix, wins/regressions, name partial credit (≥50%
  word overlap), confidence tiers. 
  - **Deploy**: patches `_SYSTEM_INSTRUCTION` in `ai_classifier.py`, writes `backend/labeling/prompts/vN.md`, updates `current.md` and
   `versions.json`. No-ops if already current.
  
  New accuracy report dimensions vs the old placeholder:

  | Dimension | What it measures |
  |-----------|-----------------|
  | Wins / Regressions | wrong→right / right→wrong vs original prompt |
  | Confusion matrix | remaining wrong predictions by category |
  | Name partial credit | normalised word overlap ≥50% |
  | Owner accuracy | `protocol_likely=True/False` vs human confirmation |
  | Confidence tiers | category accuracy split by high/mid/low |

  `reclassify_row` now calls `_is_protocol_likely()` and attaches `ai_owner_project_likely` to verify output — without this, owner
  accuracy was always 0%.

  ---
  
  ### Prompt versioning (`backend/labeling/prompts/`)

  New directory tracking the live prompt and its history:

backend/labeling/prompts/
├── versions.json   ← current pointer + history with accuracy per version
├── current.md      ← always matches _SYSTEM_INSTRUCTION in ai_classifier.py
└── v1.md           ← archived on deploy

  Deploy auto-increments version. Rollback: copy `vN.md` back into `ai_classifier.py` and update `versions.json` manually.

  ---

  ### Bug fixes

  #### `_is_protocol_likely()` (`automated_labeler.py:551`)

  Two correctness bugs fixed:

  1. `novel_tokens` override was checked *before* the `trading`/`other` hard exclusion — MEV bots trading WETH/WBTC were being flagged
   `protocol_likely=True`. Moved the check after the exclusion block.
  2. `dex` was in the fast-pass category list — unverified contracts classified as `dex` (often private routing strategies with public
   callers) were incorrectly flagged. Removed `dex` from fast-pass.
  
  Result: no-owner accuracy improved from 0/4 → 2/4 on the current ground-truth set.

  #### Chain median DAA — repeated DB connections
  
  `fetch_chain_median_daa()` was creating a new `DbConnector()` per contract during Phase 3, causing 54 connections for a 54-contract
  eval run. Added module-level `_chain_median_cache: dict[str, float] = {}` — now one DB connection per chain per process.

  #### `DbConnector.__init__` log noise

  Replaced `print("Database connection successful.")` with `pass` — was flooding eval logs with one line per contract.

  ---

  ### Prompt improvement (v1)

  `_SYSTEM_INSTRUCTION` updated with:

  - **PATH -1**: unexecuted contracts (`txcount=0`) short-circuit to `other/UnexecutedContract`
  - Strengthened `is_protocol_contract_likely` instructions with explicit `trading` override
  - GitHub repo as primary classification signal, overriding weak trace signals
  - Proxy-to-unknown-impl handling (`VerifiedProxyToUnknownImpl`)
  - Airdrop/distribution keyword pattern recognition
  - Raw-opcode ambiguity routes to `AmbiguousExecutor` instead of forcing `trading`
  - DEX interaction check added before lending/bridge in public signal cascade

  ---

  ### Cleanup

  - `context_cache.py`: removed standalone CLI — Phase 3 auto-warms on cache miss; CLI was dead code
  - `eval_human_corrections.py`: removed `--dump` default pointing to old backfill file; removed `--source json` path
  - `eval/README.md`: rewritten to reflect current 4-phase pipeline; removed all backfill-era content