### PR TITLE
feat(api): split blockspace overview/category_comparison + precomputed answer JSONs

### DIFF
--- a/backend/src/api/blockspace_json_creation.py
+++ b/backend/src/api/blockspace_json_creation.py
@@ -10,7 +10,7 @@ from src.db_connector import DbConnector
 
 class BlockspaceJSONCreation():
 
-    def __init__(self, s3_bucket, cf_distribution_id, db_connector:DbConnector, api_version):
+    def __init__(self, s3_bucket, cf_distribution_id, db_connector:DbConnector, api_version, drop_daily_7d_rolling:bool=False):
         ## Constants
         self.api_version = api_version
         self.s3_bucket = s3_bucket
@@ -18,6 +18,12 @@ class BlockspaceJSONCreation():
         self.db_connector = db_connector
         self.main_conf = get_main_config()
         self.all_l2_config = get_all_l2_config()
+
+        ## Feature flag — when ON, the SMALL category_comparison split files omit `daily_7d_rolling`
+        ## (the client recomputes it from `daily`). Default OFF; only flip ON after the frontend PR
+        ## that computes the rolling mean client-side has shipped. The large category_comparison.json
+        ## is never touched by this. Honors env var so ops can flip it without a code change.
+        self.drop_daily_7d_rolling = drop_daily_7d_rolling or os.getenv("BLOCKSPACE_DROP_DAILY_7D_ROLLING", "false").strip().lower() in ("1", "true", "yes")
 
     def _fillna_numeric(self, df: pd.DataFrame) -> pd.DataFrame:
         numeric_cols = df.select_dtypes(include="number").columns
@@ -187,20 +193,54 @@ class BlockspaceJSONCreation():
         return df
     
     ##### FILE HANDLERS #####
-    def save_to_json(self, data, path):
+    def save_to_json(self, data, path, minify=False):
         #create directory if not exists
         os.makedirs(os.path.dirname(f'output/{self.api_version}/{path}.json'), exist_ok=True)
         ## save to file
         with open(f'output/{self.api_version}/{path}.json', 'w') as fp:
-            json.dump(data, fp, ignore_nan=True)
+            if minify:
+                json.dump(data, fp, ignore_nan=True, separators=(",", ":"))
+            else:
+                json.dump(data, fp, ignore_nan=True)
 
-    def _save_or_upload_json(self, data, path, invalidate=True):
+    @staticmethod
+    def _round_sig(x, sig=6):
+        ## round a float to `sig` significant figures (not decimal places), keeping the
+        ## meaningful digits of small shares while shedding trailing float64 noise on large values.
+        if x == 0 or not math.isfinite(x):
+            return x
+        return round(x, -int(math.floor(math.log10(abs(x)))) + (sig - 1))
+
+    @classmethod
+    def _normalize_numbers(cls, o, sig=6):
+        ## Display-lossless precision normalization applied to the SMALL JSONs only:
+        ##   - integer-valued floats -> int (drops the trailing `.0`, e.g. 211515.0 -> 211515)
+        ##   - all other floats -> `sig` significant figures
+        ## Strings (addresses, names, category keys) and ints are left untouched. Builds new
+        ## containers, so the source dict (and therefore the already-written large file) is unaffected.
+        if isinstance(o, bool):
+            return o
+        if isinstance(o, float):
+            if o.is_integer():
+                return int(o)
+            return cls._round_sig(o, sig)
+        if isinstance(o, list):
+            return [cls._normalize_numbers(v, sig) for v in o]
+        if isinstance(o, dict):
+            return {k: cls._normalize_numbers(v, sig) for k, v in o.items()}
+        return o
+
+    def _save_or_upload_json(self, data, path, invalidate=True, normalize=True):
         ## single entry point that mirrors the local-vs-s3 branching used by every export.
         ## `path` is relative to the api_version root, e.g. 'blockspace/overview/base'.
+        ## Small-JSON exports are precision-normalized and minified here; the large combined files
+        ## are written via save_to_json / upload_json_to_cf_s3 directly and are NOT affected.
+        if normalize:
+            data = self._normalize_numbers(data)
         if self.s3_bucket == None:
-            self.save_to_json(data, path)
+            self.save_to_json(data, path, minify=True)
         else:
-            upload_json_to_cf_s3(self.s3_bucket, f'{self.api_version}/{path}', data, self.cf_distribution_id, invalidate=invalidate)
+            upload_json_to_cf_s3(self.s3_bucket, f'{self.api_version}/{path}', data, self.cf_distribution_id, invalidate=invalidate, minify=True)
 
     ##### ANSWER (precomputed) JSON HELPERS #####
     @staticmethod
@@ -1074,6 +1114,20 @@ class BlockspaceJSONCreation():
         self._save_or_upload_json(out, 'answers/stablecoin-activity')
         print('-- DONE -- Answer export for stablecoin-activity')
 
+    @staticmethod
+    def _strip_daily_7d_rolling(main_cat_dict):
+        ## Return a copy of one category's dict with `daily_7d_rolling` removed at the category
+        ## level and within every subcategory. Non-mutating (does not touch comparison_dict), so the
+        ## already-written large category_comparison.json and the answer JSONs are unaffected.
+        out = {k: v for k, v in main_cat_dict.items() if k != 'daily_7d_rolling'}
+        subs = main_cat_dict.get('subcategories')
+        if isinstance(subs, dict):
+            out['subcategories'] = {
+                sk: ({k: v for k, v in sv.items() if k != 'daily_7d_rolling'} if isinstance(sv, dict) else sv)
+                for sk, sv in subs.items()
+            }
+        return out
+
     def _write_blockspace_comparison_split(self, comparison_dict):
         ## Splits the combined blockspace/category_comparison.json into one file per main
         ## category so the frontend can fetch a single category instead of the full payload.
@@ -1085,6 +1139,9 @@ class BlockspaceJSONCreation():
         index = {"data": {}}
 
         for main_cat, main_cat_dict in categories.items():
+            # when the flag is ON, omit daily_7d_rolling from the split (client recomputes it from daily)
+            if self.drop_daily_7d_rolling:
+                main_cat_dict = self._strip_daily_7d_rolling(main_cat_dict)
             cat_file = {
                 "data": {main_cat: main_cat_dict}
             }

--- a/backend/src/api/blockspace_json_creation.py
+++ b/backend/src/api/blockspace_json_creation.py
@@ -1,6 +1,8 @@
 import os
+import math
 import simplejson as json
 import pandas as pd
+from datetime import datetime, timezone
 
 from src.main_config import get_main_config, get_all_l2_config
 from src.misc.helper_functions import upload_json_to_cf_s3, db_addresses_to_checksummed_addresses, fix_dict_nan, empty_cloudfront_cache, send_discord_message
@@ -192,6 +194,67 @@ class BlockspaceJSONCreation():
         with open(f'output/{self.api_version}/{path}.json', 'w') as fp:
             json.dump(data, fp, ignore_nan=True)
 
+    def _save_or_upload_json(self, data, path, invalidate=True):
+        ## single entry point that mirrors the local-vs-s3 branching used by every export.
+        ## `path` is relative to the api_version root, e.g. 'blockspace/overview/base'.
+        if self.s3_bucket == None:
+            self.save_to_json(data, path)
+        else:
+            upload_json_to_cf_s3(self.s3_bucket, f'{self.api_version}/{path}', data, self.cf_distribution_id, invalidate=invalidate)
+
+    ##### ANSWER (precomputed) JSON HELPERS #####
+    @staticmethod
+    def _resolve_value(types, row, name):
+        ## resolve a value out of a (types, row) pair by the column NAME, never a fixed index,
+        ## so an upstream reorder of `types` cannot silently corrupt the value. Returns None if
+        ## the name is absent or the row is malformed.
+        if not isinstance(types, list) or not isinstance(row, (list, tuple)):
+            return None
+        try:
+            idx = types.index(name)
+        except ValueError:
+            return None
+        if idx >= len(row):
+            return None
+        return row[idx]
+
+    @staticmethod
+    def _is_finite_positive(v):
+        return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v) and v > 0
+
+    @staticmethod
+    def _num(v):
+        ## coerce to a finite number, else 0 (used for L1/L2 totals where a missing slice == 0).
+        return v if (isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v)) else 0
+
+    @staticmethod
+    def _generated_at_iso():
+        return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    def _get_l2_universe(self):
+        ## The curated "L2 universe" shared by the answer endpoints, derived from main_config
+        ## (equivalent to master.json's deployment/bucket fields). Include a chain iff:
+        ##   - api_deployment_flag == 'PROD'  (drops DEV / ZIRCUIT)
+        ##   - bucket not in {'Layer 1', '-'}
+        ##   - origin_key not in {ethereum, polygon_pos, all_l2s, multiple}
+        ## Returns (universe_keys_sorted, excluded_non_l2_keys_sorted). excludedNonL2Keys = PROD,
+        ## non-special chains dropped by the bucket filter (keys, not display names).
+        special = {'ethereum', 'polygon_pos', 'all_l2s', 'multiple'}
+        non_l2_buckets = {'Layer 1', '-'}
+        universe = []
+        excluded = []
+        for chain in self.main_conf:
+            key = chain.origin_key
+            if key in special:
+                continue
+            if getattr(chain, 'api_deployment_flag', None) != 'PROD':
+                continue
+            if getattr(chain, 'bucket', None) in non_l2_buckets:
+                excluded.append(key)
+                continue
+            universe.append(key)
+        return sorted(universe), sorted(excluded)
+
     ##### JSON GENERATION METHODS #####
 
     def create_blockspace_overview_json(self):
@@ -349,7 +412,108 @@ class BlockspaceJSONCreation():
         else:
             upload_json_to_cf_s3(self.s3_bucket, f'{self.api_version}/blockspace/overview', overview_dict, self.cf_distribution_id)
         print(f'-- DONE -- Blockspace export for overview')
-    
+
+        ## also write the same content split into one file per chain (+ an index)
+        self._write_blockspace_overview_split(overview_dict)
+
+        ## precomputed answer endpoint derived from the same overview dict (finance category only)
+        self._write_answer_defi_l1_vs_l2(overview_dict)
+
+    def _write_answer_defi_l1_vs_l2(self, overview_dict):
+        ## /v1/answers/defi-l1-vs-l2.json — replaces frontend derivation over the full overview.json.
+        ## Source slice: chains.{chain}.overview[window].finance.data (resolved via overview.types).
+        ## L1 = ethereum, L2 = all_l2s; plus top-5 L2 contributors by finance txcount over 30d.
+        chains = overview_dict.get('data', {}).get('chains', {})
+        windows = ['7d', '30d', '90d', '180d', '365d', 'max']
+
+        def finance_metrics(chain_key, window):
+            ch = chains.get(chain_key, {})
+            ov = ch.get('overview', {})
+            types = ov.get('types')
+            fin = ov.get(window, {}).get('finance', {})
+            row = fin.get('data') if isinstance(fin, dict) else None
+            tx = self._resolve_value(types, row, 'txcount_absolute')
+            usd = self._resolve_value(types, row, 'gas_fees_usd_absolute')
+            return tx, usd
+
+        out = {
+            "generatedAtIso": self._generated_at_iso(),
+            "byWindow": {},
+            "topL2Contributors30d": []
+        }
+
+        for w in windows:
+            l1_tx, l1_usd = finance_metrics('ethereum', w)
+            l2_tx, l2_usd = finance_metrics('all_l2s', w)
+            l1_tx, l1_usd, l2_tx, l2_usd = self._num(l1_tx), self._num(l1_usd), self._num(l2_tx), self._num(l2_usd)
+            tot_tx = l1_tx + l2_tx
+            tot_usd = l1_usd + l2_usd
+            out['byWindow'][w] = {
+                "l1Txcount": l1_tx,
+                "l1GasFeesUsd": l1_usd,
+                "l2Txcount": l2_tx,
+                "l2GasFeesUsd": l2_usd,
+                "l2ShareTxcount": (l2_tx / tot_tx) if tot_tx > 0 else None,
+                "l2ShareGasFeesUsd": (l2_usd / tot_usd) if tot_usd > 0 else None,
+            }
+
+        ## top L2 contributors over 30d (every chain except the aggregates / L1s)
+        exclude = {'ethereum', 'all_l2s', 'multiple', 'polygon_pos'}
+        contribs = []
+        for key in chains:
+            if key in exclude:
+                continue
+            tx, usd = finance_metrics(key, '30d')
+            if self._is_finite_positive(tx):
+                contribs.append({
+                    "chainKey": key,
+                    "chainName": chains[key].get('chain_name'),
+                    "txcount": tx,
+                    "gasFeesUsd": self._num(usd),
+                })
+        contribs_total = sum(c['txcount'] for c in contribs)
+        for c in contribs:
+            c['shareOfL2Txs'] = (c['txcount'] / contribs_total) if contribs_total > 0 else None
+        contribs.sort(key=lambda x: x['txcount'], reverse=True)
+        out['topL2Contributors30d'] = contribs[:5]
+
+        out = fix_dict_nan(out, 'answers/defi-l1-vs-l2', False)
+        self._save_or_upload_json(out, 'answers/defi-l1-vs-l2')
+        print('-- DONE -- Answer export for defi-l1-vs-l2')
+
+    def _write_blockspace_overview_split(self, overview_dict):
+        ## Splits the combined blockspace/overview.json into one file per chain so the
+        ## frontend can fetch a single chain instead of the full payload.
+        ## Each split mirrors the combined shape exactly (drop-in subset):
+        ##   blockspace/overview/{origin_key}.json -> {"data": {"metric_id", "chains": {origin_key: ...}}}
+        ## plus blockspace/overview/index.json listing the available chains.
+        metric_id = overview_dict['data'].get('metric_id', 'overview')
+        chains = overview_dict['data']['chains']
+
+        index = {
+            "data": {
+                "metric_id": metric_id,
+                "chains": {}
+            }
+        }
+
+        for origin_key, chain_dict in chains.items():
+            chain_file = {
+                "data": {
+                    "metric_id": metric_id,
+                    "chains": {origin_key: chain_dict}
+                }
+            }
+            # invalidate=False here; we issue one wildcard invalidation at the end instead
+            self._save_or_upload_json(chain_file, f'blockspace/overview/{origin_key}', invalidate=False)
+            index['data']['chains'][origin_key] = {"chain_name": chain_dict.get('chain_name')}
+
+        self._save_or_upload_json(index, f'blockspace/overview/index', invalidate=False)
+
+        if self.s3_bucket != None:
+            empty_cloudfront_cache(self.cf_distribution_id, f'/{self.api_version}/blockspace/overview/*')
+        print(f'-- DONE -- Blockspace split export for overview ({len(chains)} chains)')
+
     def create_blockspace_single_chain_json(self, origin_keys:list=None):
         # define the timeframes in days for the overview data
         overview_timeframes = [1, 7, 30, 180, "max"]
@@ -838,6 +1002,107 @@ class BlockspaceJSONCreation():
         else:
             upload_json_to_cf_s3(self.s3_bucket, f'{self.api_version}/blockspace/category_comparison', comparison_dict, self.cf_distribution_id)
         print(f'-- DONE -- Blockspace export for category_comparison')
+
+        ## also write the same content split into one file per main category (+ an index)
+        self._write_blockspace_comparison_split(comparison_dict)
+
+        ## precomputed answer endpoint derived from the same comparison dict (stablecoin subcat only)
+        self._write_answer_stablecoin_activity(comparison_dict)
+
+    def _write_answer_stablecoin_activity(self, comparison_dict):
+        ## /v1/answers/stablecoin-activity.json — replaces frontend derivation over the full
+        ## category_comparison.json. Source slice: data.token_transfers.subcategories.stablecoin.
+        ## Two metrics x three periods, ranked top-5 over the curated L2 universe.
+        universe, excluded = self._get_l2_universe()
+        universe_set = set(universe)
+
+        out = {
+            "generatedAtIso": self._generated_at_iso(),
+            "universeSize": len(universe),
+            "universeKeys": universe,
+            "excludedNonL2Keys": excluded,
+            "byMetricByPeriod": {
+                "txcount": {"daily": [], "weekly": [], "monthly": []},
+                "gas_spent": {"daily": [], "weekly": [], "monthly": []},
+            }
+        }
+
+        subcat = (comparison_dict.get('data', {})
+                  .get('token_transfers', {})
+                  .get('subcategories', {})
+                  .get('stablecoin'))
+
+        if isinstance(subcat, dict):
+            # txcount -> txcount_absolute ; gas_spent -> gas_fees_absolute_usd (USD)
+            metrics = {"txcount": "txcount_absolute", "gas_spent": "gas_fees_absolute_usd"}
+
+            def ranked_top5(entries):
+                entries.sort(key=lambda x: x['value'], reverse=True)
+                return entries[:5]
+
+            # weekly = aggregated 7d, monthly = aggregated 30d
+            agg = subcat.get('aggregated', {})
+            for period, tf in (("weekly", "7d"), ("monthly", "30d")):
+                data_block = agg.get(tf, {}).get('data', {})
+                types = data_block.get('types')
+                for metric_key, col in metrics.items():
+                    entries = []
+                    for key, row in data_block.items():
+                        if key == 'types' or key not in universe_set:
+                            continue
+                        v = self._resolve_value(types, row, col)
+                        if self._is_finite_positive(v):
+                            entries.append({"key": key, "value": v})
+                    out['byMetricByPeriod'][metric_key][period] = ranked_top5(entries)
+
+            # daily = last element of the .daily[key] series
+            daily_block = subcat.get('daily', {})
+            daily_types = daily_block.get('types')
+            for metric_key, col in metrics.items():
+                entries = []
+                for key, series in daily_block.items():
+                    if key == 'types' or key not in universe_set:
+                        continue
+                    if not isinstance(series, list) or len(series) == 0:
+                        continue
+                    v = self._resolve_value(daily_types, series[-1], col)
+                    if self._is_finite_positive(v):
+                        entries.append({"key": key, "value": v})
+                out['byMetricByPeriod'][metric_key]['daily'] = ranked_top5(entries)
+
+        out = fix_dict_nan(out, 'answers/stablecoin-activity', False)
+        self._save_or_upload_json(out, 'answers/stablecoin-activity')
+        print('-- DONE -- Answer export for stablecoin-activity')
+
+    def _write_blockspace_comparison_split(self, comparison_dict):
+        ## Splits the combined blockspace/category_comparison.json into one file per main
+        ## category so the frontend can fetch a single category instead of the full payload.
+        ## Each split mirrors the combined shape exactly (drop-in subset):
+        ##   blockspace/category_comparison/{main_category}.json -> {"data": {main_category: ...}}
+        ## plus blockspace/category_comparison/index.json listing categories + their subcategories.
+        categories = comparison_dict['data']
+
+        index = {"data": {}}
+
+        for main_cat, main_cat_dict in categories.items():
+            cat_file = {
+                "data": {main_cat: main_cat_dict}
+            }
+            # invalidate=False here; we issue one wildcard invalidation at the end instead
+            self._save_or_upload_json(cat_file, f'blockspace/category_comparison/{main_cat}', invalidate=False)
+
+            # subcategory keys live under subcategories.list (everything else there is a sub_cat dict)
+            subcategories = main_cat_dict.get('subcategories', {}).get('list', [])
+            index['data'][main_cat] = {
+                "type": main_cat_dict.get('type', 'main_category'),
+                "subcategories": subcategories
+            }
+
+        self._save_or_upload_json(index, f'blockspace/category_comparison/index', invalidate=False)
+
+        if self.s3_bucket != None:
+            empty_cloudfront_cache(self.cf_distribution_id, f'/{self.api_version}/blockspace/category_comparison/*')
+        print(f'-- DONE -- Blockspace split export for category_comparison ({len(categories)} categories)')
 
     def create_all_jsons(self):
         self.create_blockspace_overview_json()

--- a/backend/src/misc/helper_functions.py
+++ b/backend/src/misc/helper_functions.py
@@ -694,12 +694,15 @@ def upload_json_to_cf_s3(
     cf_distribution_id: str,
     invalidate: bool = True,
     cache_control: str | None = None,
-    content_type: str = "application/json"
+    content_type: str = "application/json",
+    minify: bool = False
 ):
     """
     Uploads JSON to S3 and (optionally) sets Cache-Control headers for CloudFront.
     If `cache_control` is provided, it's sent to S3 as the object's CacheControl.
-    
+    If `minify` is True, the JSON is serialized without whitespace (separators=(",", ":"));
+    default False preserves the existing spaced output for all current callers.
+
     # Example cache setting
     SHORT_CACHE = "public, max-age=60, s-maxage=900, stale-while-revalidate=60, stale-if-error=86400"
     max-age: 60 seconds in browser cache -> after 60 seconds browser will revalidate with CDN
@@ -707,7 +710,7 @@ def upload_json_to_cf_s3(
     stale-while-revalidate: 60 seconds -> if CDN cache is stale, still serve stale content while revalidating in the background
     stale-if-error: 86400 seconds -> if CDN cannot reach S3, serve stale content for up to 24 hours
     """
-    details_json = json.dumps(details_dict)
+    details_json = json.dumps(details_dict, separators=(",", ":")) if minify else json.dumps(details_dict)
 
     s3 = boto3.client(
         "s3",


### PR DESCRIPTION
## Summary

Replicates the two large blockspace API files into smaller, frontend-friendly JSONs **without changing the existing outputs**, and adds two precomputed "answer" endpoints. All new logic is built from the dicts the existing generators already assemble — **no extra DB queries**, no new DAG tasks (the existing `run_create_blockspace_overview` / `run_create_blockspace_category_comparison` tasks emit the new files).

### Split files (drop-in subsets, contracts preserved)
- `blockspace/overview/{origin_key}.json` + `blockspace/overview/index.json`
- `blockspace/category_comparison/{main_category}.json` + `blockspace/category_comparison/index.json`

Each split mirrors the combined file's wrapper shape, filtered to one key, so frontend parsing logic is reusable. Split writes use `invalidate=False` plus one wildcard CloudFront invalidation per folder (same pattern as `create_blockspace_single_chain_json`).

### Precomputed answer endpoints (scoped to the build-time-killer slices)
- `answers/stablecoin-activity.json` — from `data.token_transfers.subcategories.stablecoin`. Two metrics (`txcount`, `gas_spent`) × three periods (daily/weekly/monthly), top-5 over the curated L2 universe.
- `answers/defi-l1-vs-l2.json` — from `chains.{chain}.overview[window].finance`. L1 (ethereum) vs L2 (all_l2s) per window + top-5 L2 contributors over 30d.

### Notes
- Every value is resolved **by column name** in the `types` arrays, never a fixed index, so an upstream reorder can't silently corrupt values.
- The "L2 universe" filter (PROD deployment, bucket not in `{Layer 1, -}`, excluding ethereum/polygon_pos/all_l2s/multiple) is derived from `main_config` rather than a parallel mapping.
- `excludedNonL2Keys` currently emits chain **keys** (e.g. `ronin`), consistent with the "hydrate by key" convention.
- Optional `supplyByPeriod` / `byVariety` (sourced from `stables_mcap.json` and quick-bites tables, not these blockspace files) are intentionally **not** included.

### Testing
Verified via offline dry-runs feeding realistic mock `overview_dict` / `comparison_dict` into the new methods — output matched the intended shapes (universe filtering, by-name resolution, top-5 ranking, null shares on zero totals, contributor exclusions). Not run against a live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)