### PR TITLE
fix(highlights): screenshot main-site fundamentals URL instead of rem…

### DIFF
--- a/backend/airflow/dags/other/other_highlights_bot.py
+++ b/backend/airflow/dags/other/other_highlights_bot.py
@@ -85,10 +85,10 @@ def highlights_bot():
                             timespan = '180d'
                         
 
-                        url = f"https://www.growthepie.com/embed/fundamentals/{metric_fe}?showUsd=true&theme=dark&timespan={timespan}&scale=stacked&interval=daily&showMainnet=true&chains={chains_url}&zoomed=false"
+                        url = f"https://www.growthepie.com/fundamentals/{metric_fe}?chains={chains_url}&hideTable=true&timespan={timespan}&scale=stacked&showUsd=true"
                         print(f"🌐 Chart URL: {url}")
                         filename = f"{date}_{metric_key}.png"
-                        generate_screenshot(url, filename, height=800, width=1400)
+                        generate_screenshot(url, filename, width=1400, height=1000, wait_for_timeout=5000, selector=r".rounded-\[18px\].bg-color-bg-default")
                         #send_discord_message(message, os.getenv("GTP_AI_WEBHOOK_URL"), image_paths=f"generated_images/{filename}")
                         send_telegram_message(TG_BOT_TOKEN, TG_CHAT_ID, message, image_path=f"generated_images/{filename}")
                     else:
@@ -159,10 +159,10 @@ def highlights_bot():
                                     timespan = '180d'
                                 
 
-                                url = f"https://www.growthepie.com/embed/fundamentals/{metric_fe}?showUsd=true&theme=dark&timespan={timespan}&scale=stacked&interval=daily&showMainnet=true&chains={chains_url}&zoomed=false"
+                                url = f"https://www.growthepie.com/fundamentals/{metric_fe}?chains={chains_url}&hideTable=true&timespan={timespan}&scale=stacked&showUsd=true"
                                 print(f"🌐 Chart URL: {url}")
                                 filename = f"{date}_{metric_key}.png"
-                                generate_screenshot(url, filename, height=800, width=1400)
+                                generate_screenshot(url, filename, width=1400, height=1000, wait_for_timeout=5000, selector=r".rounded-\[18px\].bg-color-bg-default")
                                 send_discord_message(message, os.getenv("GTP_AI_WEBHOOK_URL"), image_paths=f"generated_images/{filename}")
                                 #send_telegram_message(TG_BOT_TOKEN, TG_CHAT_ID, message, image_path=f"generated_images/{filename}")
                             else:

--- a/backend/src/misc/helper_functions.py
+++ b/backend/src/misc/helper_functions.py
@@ -479,6 +479,7 @@ def generate_screenshot(
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
         page = browser.new_page()
+        page.emulate_media(color_scheme="dark")  # site follows system prefers-color-scheme; headless defaults to light
         page.set_viewport_size({"width": width, "height": height})
 
         print(f"📸 Loading chart: {url}")


### PR DESCRIPTION
…oved /embed route

The ATH/lifetime highlight alerts loaded the frontend's chart-only /embed/fundamentals/... route to screenshot the chart. That route was removed from the frontend, breaking both the Discord and Telegram alerts.

- Point the screenshot URL at the main-site /fundamentals/{slug} page with query params (chains, hideTable, timespan, scale, showUsd).
- Clip the screenshot to the chart card via the .rounded-[18px].bg-color-bg-default selector (the main page has nav/header chrome the embed page didn't), reusing generate_screenshot's existing selector branch.
- Force dark color-scheme in generate_screenshot; the site follows system prefers-color-scheme and headless Chromium otherwise defaults to light (the old embed forced dark via theme=dark).